### PR TITLE
Cache purger now soft purges on content update events.

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -42,8 +42,8 @@ class Lambda {
     RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "")
 
   private sealed trait PurgeType
-  private object Soft extends PurgeType
-  private object Hard extends PurgeType
+  private object Soft extends PurgeType { override def toString = "soft" }
+  private object Hard extends PurgeType { override def toString = "hard" }
 
   /**
    * Send a hard purge request to Fastly API.
@@ -66,7 +66,7 @@ class Lambda {
     }).build()
 
     val response = httpClient.newCall(request).execute()
-    println(s"Sent ${purgeType.getClass.getSimpleName} purge request for content with ID [$contentId]. Response from Fastly API: [${response.code}] [${response.body.string}]")
+    println(s"Sent $purgeType purge request for content with ID [$contentId]. Response from Fastly API: [${response.code}] [${response.body.string}]")
 
     val purged = response.code == 200
     purged

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -22,9 +22,12 @@ class Lambda {
     CrierEventProcessor.process(userRecords.asScala) { event =>
       (event.itemType, event.eventType) match {
         case (ItemType.Content, EventType.Delete) =>
-          sendPurgeRequest(event.payloadId)
+          sendPurgeRequest(event.payloadId, Hard)
         case (ItemType.Content, EventType.Update) =>
-          sendSoftPurgeRequest(event.payloadId)
+          sendPurgeRequest(event.payloadId, Soft)
+        case (ItemType.Content, EventType.RetrievableUpdate) =>
+          sendPurgeRequest(event.payloadId, Soft)
+
         case other =>
           // for now we only send purges for content, so ignore any other events
           false
@@ -38,49 +41,34 @@ class Lambda {
   private val EmptyJsonBody: RequestBody =
     RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "")
 
+  private sealed trait PurgeType
+  private object Soft extends PurgeType
+  private object Hard extends PurgeType
+
   /**
    * Send a hard purge request to Fastly API.
    *
    * @return whether a piece of content was purged or not
    */
-  private def sendPurgeRequest(contentId: String): Boolean = {
-    val request = basicPurgeRequest(contentId).build()
-
-    val response = httpClient.newCall(request).execute()
-    println(s"Sent purge request for content with ID [$contentId]. Response from Fastly API: [${response.code}] [${response.body.string}]")
-
-    val purged = response.code == 200
-    purged
-  }
-
-  /**
-   * Send a soft purge request to Fastly API.
-   *
-   * See [[https://docs.fastly.com/guides/purging/soft-purges Fastly soft purging]].
-   *
-   * @return whether a piece of content was purged or not
-   */
-  private def sendSoftPurgeRequest(contentId: String): Boolean = {
-    val request = basicPurgeRequest(contentId)
-      .header("Fastly-Soft-Purge", "1")
-      .build()
-
-    val response = httpClient.newCall(request).execute()
-    println(s"Sent soft purge request for content with ID [$contentId]. Response from Fastly API: [${response.code}] [${response.body.string}]")
-
-    val purged = response.code == 200
-    purged
-  }
-
-  private def basicPurgeRequest(contentId: String): Request.Builder = {
+  private def sendPurgeRequest(contentId: String, purgeType: PurgeType): Boolean = {
     val contentPath = s"/$contentId"
     val surrogateKey = DigestUtils.md5Hex(contentPath)
     val url = s"https://api.fastly.com/service/${config.fastlyServiceId}/purge/$surrogateKey"
 
-    val request = new Request.Builder()
+    val requestBuilder = new Request.Builder()
       .url(url)
       .header("Fastly-Key", config.fastlyApiKey)
       .post(EmptyJsonBody)
-    request
+
+    val request = (purgeType match {
+      case Soft => requestBuilder.header("Fastly-Soft-Purge", "1")
+      case _ => requestBuilder
+    }).build()
+
+    val response = httpClient.newCall(request).execute()
+    println(s"Sent ${purgeType.getClass.getSimpleName} purge request for content with ID [$contentId]. Response from Fastly API: [${response.code}] [${response.body.string}]")
+
+    val purged = response.code == 200
+    purged
   }
 }

--- a/src/main/thrift/event.thrift
+++ b/src/main/thrift/event.thrift
@@ -6,7 +6,8 @@ typedef string RemovedContent
 
 enum EventType {
     Update = 1,
-    Delete = 2
+    Delete = 2,
+    RetrievableUpdate = 3
 }
 
 enum ItemType {


### PR DESCRIPTION
The website currently has a system that polls CAPI and soft purges (built before the event stream from CAPI went live).

I think this is a more effective place for it.

After this we are going to start ramping up cache times a bit.

(BTW - this is not tested yet, just some early morning coding form home)