### PR TITLE
Revert "Enable decompression"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.gu"
 description := "Lambda for purging Fastly cache based on Crier events"
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.6"
 name := "fastly-cache-purger"
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 
@@ -12,11 +12,8 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
   "org.apache.thrift" % "libthrift" % "0.9.1" force(),
   "com.twitter" %% "scrooge-core" % "4.18.0",
-  "com.gu" %% "content-api-models" % "12.1",
-  "com.gu" %% "thrift-serializer" % "3.0.0"
+  "com.gu" %% "content-api-models" % "12.1"
 )
-
-dependencyOverrides += "org.apache.thrift" % "libthrift" % "0.9.1"
 
 enablePlugins(RiffRaffArtifact, JavaAppPackaging)
 

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -2,7 +2,7 @@ package com.gu.fastly
 
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.crier.model.event.v1.Event
-import com.gu.thrift.serializer.ThriftDeserializer
+
 import scala.util.Try
 
 object CrierEventProcessor {
@@ -23,7 +23,8 @@ object CrierEventProcessor {
   }
 
   private def eventFromRecord(record: Record): Try[Event] = {
-    ThriftDeserializer.deserialize(record.getData.array)(Event)
+    val buffer = record.getData
+    Try(ThriftDeserializer.fromByteBuffer(buffer)(Event.decode))
   }
 
 }

--- a/src/main/scala/com/gu/fastly/ThriftDeserializer.scala
+++ b/src/main/scala/com/gu/fastly/ThriftDeserializer.scala
@@ -1,0 +1,22 @@
+package com.gu.fastly
+
+import java.nio.ByteBuffer
+
+import com.twitter.scrooge.ThriftStruct
+import org.apache.thrift.TBaseHelper
+import org.apache.thrift.protocol.{ TProtocol, TCompactProtocol }
+import org.apache.thrift.transport.TMemoryInputTransport
+
+object ThriftDeserializer {
+  private val protocolFactory = new TCompactProtocol.Factory()
+
+  def inputProtocolFrom(byteBuffer: ByteBuffer): TProtocol =
+    inputProtocolFrom(TBaseHelper.byteBufferToByteArray(byteBuffer))
+
+  def inputProtocolFrom(bytes: Array[Byte]): TProtocol =
+    protocolFactory.getProtocol(new TMemoryInputTransport(bytes))
+
+  def fromByteBuffer[T <: ThriftStruct](byteBuffer: ByteBuffer)(decoder: TProtocol => T): T =
+    decoder(inputProtocolFrom(byteBuffer))
+
+}


### PR DESCRIPTION
For some reason, this does not work:
```
Could not initialize class org.apache.thrift.transport.TIOStreamTransport: java.lang.NoClassDefFoundError
java.lang.NoClassDefFoundError: Could not initialize class org.apache.thrift.transport.TIOStreamTransport
at com.gu.thrift.serializer.ThriftDeserializer$.payload(ThriftDeserializer.scala:50)
at com.gu.thrift.serializer.ThriftDeserializer$.$anonfun$deserialize$1(ThriftDeserializer.scala:22)
at scala.util.Try$.apply(Try.scala:209)
at com.gu.thrift.serializer.ThriftDeserializer$.deserialize(ThriftDeserializer.scala:18)
at com.gu.thrift.serializer.ThriftDeserializer$.deserialize(ThriftDeserializer.scala:34)
at com.gu.fastly.CrierEventProcessor$.eventFromRecord(CrierEventProcessor.scala:26)
at com.gu.fastly.CrierEventProcessor$.$anonfun$process$1(CrierEventProcessor.scala:12)
at scala.collection.TraversableLike.$anonfun$flatMap$1(TraversableLike.scala:240)
at scala.collection.Iterator.foreach(Iterator.scala:937)
at scala.collection.Iterator.foreach$(Iterator.scala:937)
at scala.collection.AbstractIterator.foreach(Iterator.scala:1425)
at scala.collection.IterableLike.foreach(IterableLike.scala:70)
at scala.collection.IterableLike.foreach$(IterableLike.scala:69)
at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
at scala.collection.TraversableLike.flatMap(TraversableLike.scala:240)
at scala.collection.TraversableLike.flatMap$(TraversableLike.scala:237)
at scala.collection.AbstractTraversable.flatMap(Traversable.scala:104)
at com.gu.fastly.CrierEventProcessor$.process(CrierEventProcessor.scala:11)
at com.gu.fastly.Lambda.handle(Lambda.scala:22)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)
```