### PR TITLE
Increase lambda heap space

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -34,7 +34,7 @@ Resources:
       Description: Fastly cache purger
       Runtime: java8
       Handler: com.gu.fastly.Lambda::handle
-      MemorySize: 512
+      MemorySize: 1024
       Timeout: 15
       Events:
         KinesisEvent:


### PR DESCRIPTION
From Dec 17 at 4pm, the lambda experienced lots of errors:

![screen shot 2018-12-19 at 10 56 52](https://user-images.githubusercontent.com/629976/50216512-dd4b3680-037d-11e9-94b9-9ef5fbc3bf8a.png)

As a result, records too a very long time to be processed (it all seemed to get cleaned around midnight):

![screen shot 2018-12-19 at 11 08 14](https://user-images.githubusercontent.com/629976/50216575-0f5c9880-037e-11e9-8458-d95aecba7c95.png)

Logs point to a reason why this is happening: the lambda is running out of heap space:

![screen shot 2018-12-19 at 11 06 51](https://user-images.githubusercontent.com/629976/50216493-d45a6500-037d-11e9-9b89-786d72a37546.png)

This looks very similar to an issue we had with the mobile notifications lambda last week; increasing the heap size solved the issue.