### PR TITLE
Purge the ajax (api.nextgen.guardianapps) cache as well as theguardian.com one.

### DIFF
--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 
 import scala.util.Try
 
-case class Config(fastlyDotcomServiceId: String, fastlyApiKey: String, fastlyApiNextgenServiceId: String)
+case class Config(fastlyDotcomServiceId: String, fastlyApiNextgenServiceId: String, fastlyApiKey: String)
 
 object Config {
 
@@ -21,7 +21,7 @@ object Config {
 
     val fastlyGuardianAppsServiceId = getMandatoryConfig(properties, "fastly.apiNextgen.serviceId")
 
-    Config(fastlyServiceId, fastlyApiKey, fastlyGuardianAppsServiceId)
+    Config(fastlyServiceId, fastlyGuardianAppsServiceId, fastlyApiKey)
   }
 
   private def loadProperties(bucket: String, key: String): Try[Properties] = {

--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 
 import scala.util.Try
 
-case class Config(fastlyServiceId: String, fastlyApiKey: String)
+case class Config(fastlyDotcomServiceId: String, fastlyApiKey: String, fastlyApiNextgenServiceId: String)
 
 object Config {
 
@@ -19,7 +19,9 @@ object Config {
 
     val fastlyApiKey = getMandatoryConfig(properties, "fastly.apiKey")
 
-    Config(fastlyServiceId, fastlyApiKey)
+    val fastlyGuardianAppsServiceId = getMandatoryConfig(properties, "fastly.apiNextgen.serviceId")
+
+    Config(fastlyServiceId, fastlyApiKey, fastlyGuardianAppsServiceId)
   }
 
   private def loadProperties(bucket: String, key: String): Try[Properties] = {

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -25,6 +25,7 @@ class Lambda {
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard)
         case (ItemType.Content, EventType.Update) =>
           sendFastlyPurgeRequest(event.payloadId, Soft)
+          sendFastlyPurgeRequest(s"${event.payloadId}.json", Soft, config.fastlyApiNextgenServiceId)
         case (ItemType.Content, EventType.RetrievableUpdate) =>
           sendFastlyPurgeRequest(event.payloadId, Soft)
 
@@ -57,10 +58,10 @@ class Lambda {
    *
    * @return whether a piece of content was purged or not
    */
-  private def sendFastlyPurgeRequest(contentId: String, purgeType: PurgeType): Boolean = {
+  private def sendFastlyPurgeRequest(contentId: String, purgeType: PurgeType, serviceId: String = config.fastlyDotcomServiceId): Boolean = {
     val contentPath = s"/$contentId"
     val surrogateKey = DigestUtils.md5Hex(contentPath)
-    val url = s"https://api.fastly.com/service/${config.fastlyServiceId}/purge/$surrogateKey"
+    val url = s"https://api.fastly.com/service/$serviceId/purge/$surrogateKey"
 
     val requestBuilder = new Request.Builder()
       .url(url)


### PR DESCRIPTION
We had an issue today where the most recent post of a liveblog was taken down, but was still being displayed. This was because the ajax fastly service (api.nextgen.guardianapps) was not getting purged when the post was taken down. This changes gets the lambda to purge both the www.theguardian.com and the api.nextgen.guardianapps.co.uk fastly services. For more info see this PR: https://github.com/guardian/frontend/pull/20150

I have updated the config file in s3 with the new required property.

cc @jonathonherbert 