### PR TITLE
WIP: Write records to a Kinesis stream for twitter cache clearing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val Log4jVersion = "2.10.0"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "amazon-kinesis-client" % "1.9.1",
+  "com.amazonaws" % "amazon-kinesis-producer" % "0.14.0",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-s3" % "1.11.339",

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -25,8 +25,11 @@ Parameters:
     Description: Bucket where app settings are stored
     Type: String
     Default: fastly-cache-purger-config
-  KinesisStream:
-    Description: Name of the crier kinesis stream
+  KinesisStreamRead:
+    Description: Name of the crier kinesis stream this lambda reads from
+    Type: String
+  KinesisStreamWrite:
+    Description: Name of the kinesis stream this lambda writes to
     Type: String
 
 Resources:
@@ -54,7 +57,7 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       BatchSize: 100
-      EventSourceArn: !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStream}"
+      EventSourceArn: !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamRead}"
       FunctionName: !Ref Lambda
       StartingPosition: TRIM_HORIZON
   LambdaRole:
@@ -71,6 +74,14 @@ Resources:
                 - s3:GetObject
                 - s3:ListBucket
               Resource: !Sub arn:aws:s3:::${ConfigBucket}/*
+              Effect: Allow
+        - PolicyName: PutRecordsOnKinesisWriteStream
+          PolicyDocument:
+            Statement:
+              Action:
+                - kinesis:PutRecord
+                - kinesis:PutRecords
+              Resource: !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStreamWrite}
               Effect: Allow
       AssumeRolePolicyDocument:
         Version: "2012-10-17"

--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -3,6 +3,7 @@ package com.gu.fastly
 import java.util.Properties
 
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.regions.Regions
 
 import scala.util.Try
 

--- a/src/main/scala/com/gu/fastly/PurgedEventWriter.scala
+++ b/src/main/scala/com/gu/fastly/PurgedEventWriter.scala
@@ -1,0 +1,26 @@
+package com.gu.fastly
+
+import com.amazonaws.services.kinesis.model.Record
+import com.amazonaws.services.kinesis.producer.{ KinesisProducer, UserRecordResult }
+import com.google.common.util.concurrent.{ FutureCallback, Futures, ListenableFuture }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ Future, Promise }
+
+object PurgedEventWriter {
+
+  def addRecords(records: List[Record], producer: KinesisProducer): Future[List[UserRecordResult]] = Future.traverse(records)(r =>
+    producer.addUserRecord("fastly-cache-purger-events", r.getPartitionKey, r.getData).asScala)
+
+  implicit class RichListenableFuture[T](lf: ListenableFuture[T]) {
+    def asScala: Future[T] = {
+      val p = Promise[T]()
+      Futures.addCallback(lf, new FutureCallback[T] {
+        def onFailure(t: Throwable): Unit = p failure t
+        def onSuccess(result: T): Unit = p success result
+      })
+      p.future
+    }
+  }
+
+}


### PR DESCRIPTION
I have a [service](https://github.com/guardian/twitter-cache-clearing) which currently reads from CAPI's Crier events stream and sends requests to Twitter to refresh Twitter's cached representation of Guardian content, but unfortunately this refresh often happens before Fastly's cache has been purged.

This means that Twitter re-fetches the old content from Fastly, and the old content remains on Twitter.

I would like to add to this Fastly cache purger to write the Crier records to another Kinesis stream, so that the [twitter-cache-clearing](https://github.com/guardian/twitter-cache-clearing) service can read from this rather than Crier. That way, the Twitter refresh can happen after the Fastly cache has been purged.

I could do with a hand testing this, and getting sign off on the implementation. I've attempted to leave the existing code as unchanged as possible, passing the raw events to a second processor for the sake of writing to a stream.

cc @philmcmahon 