### PR TITLE
WIP: Return successfully purged content IDs for Twitter cache clearing

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -36,7 +36,7 @@ Resources:
       FunctionName: !Sub "${App}-${Stage}"
       Description: Fastly cache purger
       Runtime: java8
-      Handler: com.gu.fastly.Lambda::handle
+      Handler: com.gu.fastly.Lambda::handleRequest
       MemorySize: 512
       Timeout: 15
       Role: !GetAtt LambdaRole.Arn

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -7,8 +7,8 @@ import com.gu.thrift.serializer.ThriftDeserializer
 import scala.util.{ Success, Try }
 
 object CrierEventProcessor {
-  def decodeRecord: Record => Try[Event] = { r =>
-    val tryEvent = ThriftDeserializer.deserialize(r.getData.array)(Event)
+  def decodeRecord(record: Record): Try[Event] = {
+    val tryEvent = ThriftDeserializer.deserialize(record.getData.array)(Event)
     tryEvent.failed.foreach(_ => println("Failed to deserialize Crier event from Kinesis record. Skipping."))
     tryEvent
   }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,44 +1,48 @@
 package com.gu.fastly
 
-import org.apache.commons.codec.digest.DigestUtils
-import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
+import java.io.IOException
+
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
+import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType }
+import com.gu.fastly.CrierEventProcessor.{ decodeRecord, successfulEvents }
 import okhttp3._
-import com.gu.crier.model.event.v1._
+import org.apache.commons.codec.digest.DigestUtils
+
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ Future, Promise }
 
 class Lambda {
 
   private val config = Config.load()
   private val httpClient = new OkHttpClient()
 
-  def handle(event: KinesisEvent) {
+  def handle(event: KinesisEvent): Future[Unit] = {
     val rawRecords: List[Record] = event.getRecords.asScala.map(_.getKinesis).toList
-    val userRecords = UserRecord.deaggregate(rawRecords.asJava)
 
-    println(s"Processing ${userRecords.size} records ...")
-
-    CrierEventProcessor.process(userRecords.asScala) { event =>
-      (event.itemType, event.eventType) match {
-        case (ItemType.Content, EventType.Delete) =>
-          sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-        case (ItemType.Content, EventType.Update) =>
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequest(s"${event.payloadId}.json", Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"${event.payloadId}.json"), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequest(s"${event.payloadId}.json", Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(s"${event.payloadId}.json"), config.fastlyMapiApiKey)
-        case (ItemType.Content, EventType.RetrievableUpdate) =>
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
-
-        case other =>
-          // for now we only send purges for content, so ignore any other events
-          false
+    Future.traverse(
+      rawRecords.map(decodeRecord) collect (successfulEvents andThen decidePurgeType)
+    ) {
+        case Left(id) => purgeDelete(id).map(results => (id, results))
+        case Right(id) => purgeUpdate(id).map(results => (id, results))
+      }.flatMap { results: List[(Id, List[PurgeResult])] =>
+        log(results)
+        val ids = results.collect(idForFullySuccessfulPurge)
+        twitter(ids)
       }
-    }
-
-    println(s"Finished.")
   }
+
+  type Id = String
+
+  sealed trait Service
+
+  object AMP extends Service { override def toString = "AMP" }
+  object Dotcom extends Service { override def toString = "Dotcom" }
+  object Nextgen extends Service { override def toString = "Nextgen" }
+  object Mapi extends Service { override def toString = "Mapi" }
+
+  case class PurgeResult(status: Boolean, service: Service)
 
   // OkHttp requires a media type even for an empty POST body
   private val EmptyJsonBody: RequestBody =
@@ -56,11 +60,43 @@ class Lambda {
     dotcomSurrogateKey
   }
 
-  private def sendFastlyPurgeRequestAndAmpPingRequest(contentId: String, purgeType: PurgeType, serviceId: String, surrogateKey: String, fastlyApiKey: String): Boolean = {
-    if (sendFastlyPurgeRequest(contentId, purgeType, serviceId, surrogateKey, fastlyApiKey))
-      sendAmpPingRequest(contentId)
-    else
-      false
+  // Left[Id] for Delete, Right[Id] for Update
+  def decidePurgeType: PartialFunction[Event, Either[Id, Id]] = {
+    case Event(_, EventType.Update, _, _, Some(EventPayload.Content(content))) => Right(content.id)
+    case Event(_, EventType.RetrievableUpdate, _, _, Some(EventPayload.RetrievableContent(content))) => Right(content.id)
+    case Event(_, EventType.Delete, _, _, Some(EventPayload.RetrievableContent(content))) => Left(content.id)
+  }
+
+  def purgeDelete: Id => Future[List[PurgeResult]] = { id =>
+    val fastlyResult: Future[Boolean] = sendFastlyPurgeRequest(id, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(id), config.fastlyDotcomApiKey)
+    val ampResult: Future[Boolean] = fastlyResult.flatMap(if (_) sendAmpPingRequest(id) else Future.successful(false))
+    Future.sequence(fastlyResult.map(PurgeResult(_, Dotcom)) :: ampResult.map(PurgeResult(_, AMP)) :: Nil)
+  }
+
+  def purgeUpdate: Id => Future[List[PurgeResult]] = { id =>
+    Future.sequence(
+      sendFastlyPurgeRequest(id, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(id), config.fastlyDotcomApiKey).map(PurgeResult(_, Dotcom)) ::
+        sendFastlyPurgeRequest(id, Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(id), config.fastlyDotcomApiKey).map(PurgeResult(_, Nextgen)) ::
+        sendFastlyPurgeRequest(id, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(id), config.fastlyMapiApiKey).map(PurgeResult(_, Mapi)) ::
+        Nil
+    )
+  }
+
+  def log: List[(Id, List[PurgeResult])] => Unit = { results =>
+    val purgeResultCounts = results.flatMap(_._2).groupBy(identity).mapValues(_.size)
+    purgeResultCounts.foreach {
+      case (PurgeResult(true, service), idCount) => println(s"Successfully purged $service for $idCount content ids")
+      case (PurgeResult(false, service), idCount) => println(s"Failed to purge $service for $idCount content ids")
+    }
+  }
+
+  def idForFullySuccessfulPurge: PartialFunction[(Id, List[PurgeResult]), Id] = {
+    case (id, results) if results.forall(_.status) => id
+  }
+
+  def twitter: List[Id] => Future[Unit] = { ids =>
+    println(s"Writing ${ids.size} content ids to SQS for Twitter cache clearing")
+    Future.successful(Unit)
   }
 
   /**
@@ -68,7 +104,7 @@ class Lambda {
    *
    * @return whether a piece of content was purged or not
    */
-  def sendFastlyPurgeRequest(contentId: String, purgeType: PurgeType, serviceId: String, surrogateKey: String, fastlyApiKey: String): Boolean = {
+  def sendFastlyPurgeRequest(contentId: String, purgeType: PurgeType, serviceId: String, surrogateKey: String, fastlyApiKey: String): Future[Boolean] = {
     val url = s"https://api.fastly.com/service/$serviceId/purge/$surrogateKey"
 
     val requestBuilder = new Request.Builder()
@@ -81,19 +117,27 @@ class Lambda {
       case _ => requestBuilder
     }).build()
 
-    val response = httpClient.newCall(request).execute()
-    println(s"Sent $purgeType purge request for content with ID [$contentId], service with ID [$serviceId] and surrogate key [$surrogateKey]. Response from Fastly API: [${response.code}] [${response.body.string}]")
-
-    val purged = response.code == 200
-    purged
+    val promise = Promise[Boolean]()
+    httpClient.newCall(request).enqueue(new Callback {
+      override def onFailure(call: Call, e: IOException) = {
+        println(s"Failed to send $purgeType purge request for content with ID [$contentId], service with ID [$serviceId] and surrogate key [$surrogateKey]. Okhttp request exception: $e")
+        promise.failure(e)
+      }
+      override def onResponse(call: Call, resp: Response) = {
+        println(s"Sent $purgeType purge request for content with ID [$contentId], service with ID [$serviceId] and surrogate key [$surrogateKey]. Response from Fastly API: [${resp.code}] [${resp.body.string}]")
+        promise.success(resp.code == 200)
+      }
+    })
+    promise.future
   }
+
   /**
    * Send a ping request to Google AMP to refresh the cache.
    * See https://developers.google.com/amp/cache/update-ping
    *
    * @return whether the request was successfully processed by the server
    */
-  private def sendAmpPingRequest(contentId: String): Boolean = {
+  private def sendAmpPingRequest(contentId: String): Future[Boolean] = {
     val contentPath = s"/$contentId"
 
     val url = s"https://amp-theguardian-com.cdn.ampproject.org/update-ping/c/s/amp.theguardian.com${contentPath}"
@@ -103,10 +147,18 @@ class Lambda {
       .get()
       .build()
 
-    val response = httpClient.newCall(request).execute()
-    println(s"Sent ping request for content with ID [$contentId]. Response from Google AMP CDN: [${response.code}] [${response.body.string}]")
+    val promise = Promise[Boolean]()
 
-    response.code == 204
+    httpClient.newCall(request).enqueue(new Callback {
+      override def onFailure(call: Call, e: IOException) = {
+        println(s"Failed to send AMP ping request for content with ID [$contentId]. Okhttp request exception: $e")
+        promise.failure(e)
+      }
+      override def onResponse(call: Call, resp: Response) = {
+        println(s"Sent ping request for content with ID [$contentId]. Response from Google AMP CDN: [${resp.code}] [${resp.body.string}]")
+        promise.success(resp.code == 204)
+      }
+    })
+    promise.future
   }
-
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -88,7 +88,7 @@ class Lambda extends RequestHandler[KinesisEvent, Unit] {
   //See https://docs.fastly.com/en/guides/soft-purges
   def softPurge(contentId: ContentId): Future[List[PurgeResult]] = {
     val dotcomResult = sendFastlyPurgeRequest(contentId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(contentId), config.fastlyDotcomApiKey).map(PurgeResult(contentId, _, Dotcom))
-    val nextgenResult = sendFastlyPurgeRequest(contentId, Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(contentId), config.fastlyDotcomApiKey).map(PurgeResult(contentId, _, Nextgen))
+    val nextgenResult = sendFastlyPurgeRequest(contentId, Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"$contentId.json"), config.fastlyDotcomApiKey).map(PurgeResult(contentId, _, Nextgen))
     val mapiResult = sendFastlyPurgeRequest(contentId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(contentId), config.fastlyMapiApiKey).map(PurgeResult(contentId, _, Mapi))
 
     Future.sequence(List(dotcomResult, nextgenResult, mapiResult))

--- a/src/test/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/test/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -4,6 +4,8 @@ import com.amazonaws.services.kinesis.model.Record
 import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType, ItemType, RetrievableContent }
 import com.gu.thrift.serializer._
 import java.nio.ByteBuffer
+
+import com.gu.fastly.CrierEventProcessor.{ decodeRecord, successfulEvents }
 import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
 
 class CrierEventProcessorSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
@@ -25,13 +27,13 @@ class CrierEventProcessorSpec extends WordSpecLike with MustMatchers with OneIns
     "properly deserialize a compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, Some(ZstdType), None)
       val record = new Record().withData(ByteBuffer.wrap(bytes))
-      CrierEventProcessor.process(List(record))(event => true) mustEqual 1
+      (List(record).map(decodeRecord) collect successfulEvents).size mustEqual 1
     }
 
     "properly deserialize a non-compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, None, None)
       val record = new Record().withData(ByteBuffer.wrap(bytes))
-      CrierEventProcessor.process(List(record))(event => true) mustEqual 1
+      (List(record).map(decodeRecord) collect successfulEvents).size mustEqual 1
     }
   }
 }


### PR DESCRIPTION
This is in preparation for forwarding on successfully purged content IDs to the twitter-cache-clearing service. Here I make the content IDs for successfully purged events available at the end of the processing, and also change the purging to happen asynchronously.

In PR #16 I outlined the motivation for returning purged content, and received some feedback from @philmcmahon about a suitable approach. We discussed:

1) Cost
The initial suggestion proposed events were forwarded on to Kinesis. It was pointed out that this was expensive, and unnecessary if we don't need to replay event processing from the stream. A better approach would be to write to SQS, SNS -> SQS, or hit an API Gateway / Step Function integrated with the twitter-cache-clearing service instead.

2) Resilience
We can't "fire and forget" requests to Kinesis, so problems with the stream may impact the availability of the fastly-cache-purger. Instead, we should use one of the approaches in 1).

3) (assumed fastly-cache-purger processes were asynchronous/non-blocking) Order of processes
Could we guarantee the events would be written after the purge request was sent? This concern assumed the current processing was asynchronous, when in fact it is not. Which raises the question, why is it synchronous when we could more efficiently send different purge requests at the same time?
One reservation about switching this to be asynchronous was that Lambdas do not work nicely with asynchronous code - how do you guarantee that the Lambda won't terminate before the process finishes? I don't think this is a problem so long as we await the result of the future, with a timeout of the time available taken from the context of the Lambda. A Lambda with synchronous code would still shut down after the time available regardless of whether or not the process had finished, so this async change doesn't introduce this problem. If anything, we can expect this to be less of a problem since the async processing should happen faster.

3) Cross account permissioning
Currently the fastly-cache-purger and the twitter-cache-clearing services are in different accounts (frontend?? and capi). It would be easier if the twitter-cache-clearing service was in the same account as the fastly-cache-purger for permissioning it to read from the SQS queue. The only reason the twitter-cache-clearing service is in the capi account is because it was reading from the CAPI crier kinesis stream. If we are switching the source of events it would be nice to bring the service up in frontend instead. TODO: get agreement to do this
