### PR TITLE
AMP update-ping has been deprecated in favour of update-cache

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -89,14 +89,14 @@ class Lambda {
   }
   /**
    * Send a ping request to Google AMP to refresh the cache.
-   * See https://developers.google.com/amp/cache/update-ping
+   * See https://developers.google.com/amp/cache/update-cache
    *
    * @return whether the request was successfully processed by the server
    */
   private def sendAmpPingRequest(contentId: String): Boolean = {
     val contentPath = s"/$contentId"
 
-    val url = s"https://amp-theguardian-com.cdn.ampproject.org/update-ping/c/s/amp.theguardian.com${contentPath}"
+    val url = s"https://amp-theguardian-com.cdn.ampproject.org/update-cache/c/s/amp.theguardian.com${contentPath}"
 
     val request = new Request.Builder()
       .url(url)


### PR DESCRIPTION
## What does this change?

The AMP CDN update-ping end point has apparently been deprecated in favour of update-cache:
https://developers.google.com/amp/cache/update-cache

Seen while reading this code; PRing to document it in case anyone's interested.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

AMP pages should keep refreshing; if Google ever hard deprecates ping we'd not have to react immediately.

## Have we considered potential risks?

If this is incorrect we'd not correctly refresh AMP pages.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->