### PR TITLE
Spike - Does the Fastly decacher know if has decached an article?

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -121,13 +121,15 @@ class Lambda {
       case EventType.Update =>
         // An update event for content contain an optional RetrievableContent item as the payload.
         // (Crier KinesisEventSender.buildRetrievablePayload will have downcast from Content to KinesisEventSender before sending)
-        event.payload.foreach {
-          case retrievableContent: RetrievableContent =>
-            // RetrievableContent content does not contain the content type or webUrl we want;
-            // We will need to callback to CAPI to resolve these.
-            // The majority of these calls be for the uninteresting content types like fronts
-            // println(s"Saw purge of article with contentId [$contentId] and webUrl [$contentWebUrl]")
-            val contentCapiUrl = retrievableContent.capiUrl
+        event.payload.foreach { payload =>
+          payload.containedValue() match {
+            case retrievableContent: RetrievableContent =>
+              // RetrievableContent content does not contain the content type or webUrl we want;
+              // We will need to callback to CAPI to resolve these.
+              // The majority of these calls be for the uninteresting content types like fronts
+              // println(s"Saw purge of article with contentId [$contentId] and webUrl [$contentWebUrl]")
+              val contentCapiUrl = retrievableContent.capiUrl
+          }
         }
     }
     true


### PR DESCRIPTION
If so, then it will be able to decide whether or not to ping Facebook Newstab.

Facebook Newstab is interested in articles.
Most of the Fastly decache content ids are fronts.
We need to resolve the content type to determine if Facebook needs to informed of this decache.

The challenge is we seem to receive a RetrievableContent payload which does not contain the content type or the webUrl.

To resolve this we can either:
- bulk up the RetrievableContent event to contain content type and webUrl.
- call back to CAPI from the Fastly Lambda to obtain this information.

The later seems to be what RetrievableContent implies.
In which case a CAPI callback needs to be built.


## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
