### PR TITLE
Send Facebook Newstab proof of concept pings on content update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ name := "fastly-cache-purger"
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 
 val awsClientVersion = "1.11.918"
+val circeVersion = "0.12.3"
 val Log4jVersion = "2.10.0"
 
 libraryDependencies ++= Seq(
@@ -20,6 +21,9 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
+  "io.circe" %% "circe-core" % circeVersion,
+  "io.circe" %% "circe-generic" % circeVersion,
+  "io.circe" %% "circe-parser" % circeVersion,
   "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )
 

--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -6,7 +6,8 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 
 import scala.util.Try
 
-case class Config(fastlyDotcomServiceId: String, fastlyMapiServiceId: String, fastlyApiNextgenServiceId: String, fastlyDotcomApiKey: String, fastlyMapiApiKey: String)
+case class Config(fastlyDotcomServiceId: String, fastlyMapiServiceId: String, fastlyApiNextgenServiceId: String, fastlyDotcomApiKey: String, fastlyMapiApiKey: String,
+                  facebookNewsTabAccessToken: String, facebookNewsTabScope: String)
 
 object Config {
 
@@ -25,7 +26,12 @@ object Config {
 
     val fastlyMapiApiKey = getMandatoryConfig(properties, "fastly.MapiApiKey")
 
-    Config(fastlyDotcomServiceId, fastlyMapiServiceId, fastlyGuardianAppsServiceId, fastlyDotcomApiKey, fastlyMapiApiKey)
+    val facebookNewsTabAccessToken = getMandatoryConfig(properties, "facebook.newstab.accessToken")
+
+    val facebookNewsTabScope = getMandatoryConfig(properties, "facebook.newstab.scope")
+
+    Config(fastlyDotcomServiceId, fastlyMapiServiceId, fastlyGuardianAppsServiceId, fastlyDotcomApiKey, fastlyMapiApiKey,
+      facebookNewsTabAccessToken, facebookNewsTabScope)
   }
 
   private def loadProperties(bucket: String, key: String): Try[Properties] = {

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -169,10 +169,10 @@ class Lambda {
       .addQueryParameter("id", contentWebUrl)
       .addQueryParameter("scopes", scope)
       .addQueryParameter("access_token", config.facebookNewsTabAccessToken)
-      // TODO scape parameter; does this need to be set differently on initial submissions and updates
+      .addQueryParameter("scrape", "true")
       .build();
 
-    val emptyRequestBody = RequestBody // TODO check this
+    val emptyRequestBody = RequestBody
     val request = new Request.Builder()
       .url(indexArticle)
       .post(emptyRequestBody)

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -41,6 +41,9 @@ class Lambda {
           sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
           sendFacebookNewstabPing(event.payloadId)
+
+        case _ =>
+          true
       }
     }
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -151,8 +151,8 @@ class Lambda {
     val contentPath = s"/$contentId"
     val contentWebUrl = s"https://www.theguardian.com${contentPath}"
 
-    val scope = "new_tab_dev_env" // TODO push to config
-    val accessToken = "TODO"
+    val scope = config.facebookNewsTabScope
+    val accessToken = config.facebookNewsTabAccessToken
 
     // The POST endpoint with URL encoded parameters as per New Tab documentation
     val indexArticleUrl = "https://graph.facebook.com?id=" + contentWebUrl +  // TODO proper encoding

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -183,15 +183,17 @@ class Lambda {
     // Soft evaluate the Facebook response
     // Their documentation does not specifically mention response codes.
     // Lets evaluate and log our interpretation of the response for now
-    val wasSuccessful = if (response.code == 200) {
-      decode[FacebookNewstabResponse](response.body.string()).fold({ error =>
-        println("Failed to parse Facebook Newstab response: " + error.getMessage)
+    val wasSuccessful = response.code match {
+      case 200 =>
+        decode[FacebookNewstabResponse](response.body.string()).fold({ error =>
+          println("Failed to parse Facebook Newstab response: " + error.getMessage)
+          false
+        }, { facebookResponse =>
+          facebookResponse.scopes.get(scope).contains("INDEXED")
+        })
+      case _ =>
+        println("Received unexpected response code from Facebook: " + _)
         false
-      }, { facebookResponse =>
-        facebookResponse.scopes.get(scope).contains("INDEXED")
-      })
-    } else {
-      false
     }
 
     println(s"Sent Facebook Newstab ping request for content with url [$contentWebUrl]. " +

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -151,17 +151,18 @@ class Lambda {
     val contentPath = s"/$contentId"
     val contentWebUrl = s"https://www.theguardian.com${contentPath}"
 
-    val scope = config.facebookNewsTabScope
-    val accessToken = config.facebookNewsTabAccessToken
-
     // The POST endpoint with URL encoded parameters as per New Tab documentation
-    val indexArticleUrl = "https://graph.facebook.com?id=" + contentWebUrl +  // TODO proper encoding
-      "&scopes=" + scope +
-      "&access_token=" + accessToken
+    val indexArticle = new HttpUrl.Builder()
+      .scheme("https")
+      .host("graph.facebook.com")
+      .addQueryParameter("id", contentWebUrl)
+      .addQueryParameter("scopes", config.facebookNewsTabScope)
+      .addQueryParameter("access_token", config.facebookNewsTabAccessToken)
+      .build();
 
     val emptyRequestBody = RequestBody  // TODO check this
     val request = new Request.Builder()
-      .url(indexArticleUrl)
+      .url(indexArticle)
       .post(emptyRequestBody)
       .build()
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -32,7 +32,7 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
           sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
-          logArticleUpdates(event)
+          sendFacebookNewstabPing(event.payloadId)
 
         case (ItemType.Content, EventType.RetrievableUpdate) =>
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
@@ -147,23 +147,28 @@ class Lambda {
    * Identify if the content update was an article.
    * Additional third parties may be interested in these in the near future
    */
-  def logArticleUpdates(event: Event): Boolean = {
-    event.eventType match {
-      case EventType.Update =>
-        // An update event for content contain an optional RetrievableContent item as the payload.
-        // (Crier KinesisEventSender.buildRetrievablePayload will have downcast from Content to KinesisEventSender before sending)
-        event.payload.foreach { payload =>
-          payload.containedValue() match {
-            case retrievableContent: RetrievableContent =>
-              // RetrievableContent content does not contain the content type or webUrl we want;
-              // We will need to callback to CAPI to resolve these.
-              // The majority of these calls be for the uninteresting content types like fronts
-              // println(s"Saw purge of article with contentId [$contentId] and webUrl [$contentWebUrl]")
-              val contentCapiUrl = retrievableContent.capiUrl
-          }
-        }
-    }
-    true
+  def sendFacebookNewstabPing(contentId: String): Boolean = {
+    val contentPath = s"/$contentId"
+    val contentWebUrl = s"https://www.theguardian.com${contentPath}"
+
+    val scope = "new_tab_dev_env" // TODO push to config
+    val accessToken = "TODO"
+
+    // The POST endpoint with URL encoded parameters as per New Tab documentation
+    val indexArticleUrl = "https://graph.facebook.com?id=" + contentWebUrl +  // TODO proper encoding
+      "&scopes=" + scope +
+      "&access_token=" + accessToken
+
+    val emptyRequestBody = RequestBody  // TODO check this
+    val request = new Request.Builder()
+      .url(indexArticleUrl)
+      .post(emptyRequestBody)
+      .build()
+
+    val response = httpClient.newCall(request).execute()
+    println(s"Sent Newstab ping request for content with ID [$contentId]. Response from Facebook: [${response.code}] [${response.body.string}]")
+
+    response.code == 200  // Check response code and parse body for INDEXED response
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -52,14 +52,8 @@ class Lambda {
     RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "")
 
   private sealed trait PurgeType
-
-  private object Soft extends PurgeType {
-    override def toString = "soft"
-  }
-
-  private object Hard extends PurgeType {
-    override def toString = "hard"
-  }
+  private object Soft extends PurgeType { override def toString = "soft" }
+  private object Hard extends PurgeType { override def toString = "hard" }
 
   def makeMapiSurrogateKey(contentId: String): String = s"Item/$contentId"
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -161,46 +161,57 @@ class Lambda {
     val contentPath = s"/$contentId"
     val contentWebUrl = s"https://www.theguardian.com${contentPath}"
 
-    val scope = config.facebookNewsTabScope
+    // This is an interesting question which will almost certainly by iterated on.
+    // Basing this decision entirely on the contentId is unlikely age well.
+    // Our opening move for the proof of concept is to dibble a small amount of content which is unlikely to be taken down.
+    // Travel articles sound safe.
+    val contentIsInterestingToFacebookNewstab = contentId.contains("travel/2020")
 
-    // The POST endpoint with URL encoded parameters as per New Tab documentation
-    val indexArticle = new HttpUrl.Builder()
-      .scheme("https")
-      .host("graph.facebook.com")
-      .addQueryParameter("id", contentWebUrl)
-      .addQueryParameter("scopes", scope)
-      .addQueryParameter("access_token", config.facebookNewsTabAccessToken)
-      .addQueryParameter("scrape", "true")
-      .build();
+    if (contentIsInterestingToFacebookNewstab) {
+      val scope = config.facebookNewsTabScope
 
-    val request = new Request.Builder()
-      .url(indexArticle)
-      .post(EmptyJsonBody)
-      .build()
+      // The POST endpoint with URL encoded parameters as per New Tab documentation
+      val indexArticle = new HttpUrl.Builder()
+        .scheme("https")
+        .host("graph.facebook.com")
+        .addQueryParameter("id", contentWebUrl)
+        .addQueryParameter("scopes", scope)
+        .addQueryParameter("access_token", config.facebookNewsTabAccessToken)
+        .addQueryParameter("scrape", "true")
+        .build();
 
-    val response = httpClient.newCall(request).execute()
+      val request = new Request.Builder()
+        .url(indexArticle)
+        .post(EmptyJsonBody)
+        .build()
 
-    // Soft evaluate the Facebook response
-    // Their documentation does not specifically mention response codes.
-    // Lets evaluate and log our interpretation of the response for now
-    val wasSuccessful = response.code match {
-      case 200 =>
-        decode[FacebookNewstabResponse](response.body.string()).fold({ error =>
-          println("Failed to parse Facebook Newstab response: " + error.getMessage)
+      val response = httpClient.newCall(request).execute()
+
+      // Soft evaluate the Facebook response
+      // Their documentation does not specifically mention response codes.
+      // Lets evaluate and log our interpretation of the response for now
+      val wasSuccessful = response.code match {
+        case 200 =>
+          decode[FacebookNewstabResponse](response.body.string()).fold({ error =>
+            println("Failed to parse Facebook Newstab response: " + error.getMessage)
+            false
+          }, { facebookResponse =>
+            facebookResponse.scopes.get(scope).contains("INDEXED")
+          })
+        case _ =>
+          println("Received unexpected response code from Facebook: " + _)
           false
-        }, { facebookResponse =>
-          facebookResponse.scopes.get(scope).contains("INDEXED")
-        })
-      case _ =>
-        println("Received unexpected response code from Facebook: " + _)
-        false
+      }
+
+      println(s"Sent Facebook Newstab ping request for content with url [$contentWebUrl]. " +
+        s"Response from Facebook: [${response.code}] [${response.body.string}]. " +
+        s"Was successful: [$wasSuccessful]")
+
+      true // Always return true during the proof on concept until we are confident about Facebook's responses
+
+    } else {
+      true
     }
-
-    println(s"Sent Facebook Newstab ping request for content with url [$contentWebUrl]. " +
-      s"Response from Facebook: [${response.code}] [${response.body.string}]. " +
-      s"Was successful: [$wasSuccessful]")
-
-    true // Always return true during the proof on concept until we are confident about Facebook's responses
   }
 
   case class FacebookNewstabResponse(url: String, scopes: Map[String, String])

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -175,10 +175,10 @@ class Lambda {
       .addQueryParameter("scrape", "true")
       .build();
 
-    val emptyRequestBody = RequestBody
+    val emptyRequestBody = null
     val request = new Request.Builder()
       .url(indexArticle)
-      .post(emptyRequestBody)
+      .post(null)
       .build()
 
     val response = httpClient.newCall(request).execute()

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -40,6 +40,9 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
           sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
+          // TODO why are these .json decaches omitted for RetrievableUpdate?
+          // These seem to be different representations of equilivant events differing only on content size?
+          sendFacebookNewstabPing(event.payloadId)
 
         case other =>
           // for now we only send purges for content, so ignore any other events

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -152,13 +152,15 @@ class Lambda {
       case EventType.Update =>
         // An update event for content contain an optional RetrievableContent item as the payload.
         // (Crier KinesisEventSender.buildRetrievablePayload will have downcast from Content to KinesisEventSender before sending)
-        event.payload.foreach {
-          case retrievableContent: RetrievableContent =>
-            // RetrievableContent content does not contain the content type or webUrl we want;
-            // We will need to callback to CAPI to resolve these.
-            // The majority of these calls be for the uninteresting content types like fronts
-            // println(s"Saw purge of article with contentId [$contentId] and webUrl [$contentWebUrl]")
-            val contentCapiUrl = retrievableContent.capiUrl
+        event.payload.foreach { payload =>
+          payload.containedValue() match {
+            case retrievableContent: RetrievableContent =>
+              // RetrievableContent content does not contain the content type or webUrl we want;
+              // We will need to callback to CAPI to resolve these.
+              // The majority of these calls be for the uninteresting content types like fronts
+              // println(s"Saw purge of article with contentId [$contentId] and webUrl [$contentWebUrl]")
+              val contentCapiUrl = retrievableContent.capiUrl
+          }
         }
     }
     true

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -40,8 +40,6 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
           sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
-          // TODO why are these .json decaches omitted for RetrievableUpdate?
-          // These seem to be different representations of equilivant events differing only on content size?
           sendFacebookNewstabPing(event.payloadId)
 
         case other =>

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -42,8 +42,9 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
           sendFacebookNewstabPing(event.payloadId)
 
-        case _ =>
-          true
+        case other =>
+          // for now we only send purges for content, so ignore any other events
+          false
       }
     }
 
@@ -104,7 +105,6 @@ class Lambda {
 
     purged
   }
-
   /**
    * Send a ping request to Google AMP to refresh the cache.
    * See https://developers.google.com/amp/cache/update-ping

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -41,10 +41,6 @@ class Lambda {
           sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
           sendFacebookNewstabPing(event.payloadId)
-
-        case other =>
-          // for now we only send purges for content, so ignore any other events
-          false
       }
     }
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -175,10 +175,9 @@ class Lambda {
       .addQueryParameter("scrape", "true")
       .build();
 
-    val emptyRequestBody = null
     val request = new Request.Builder()
       .url(indexArticle)
-      .post(null)
+      .post(EmptyJsonBody)
       .build()
 
     val response = httpClient.newCall(request).execute()

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -147,6 +147,11 @@ class Lambda {
    * Identify if the content update was an article.
    * Additional third parties may be interested in these in the near future
    */
+  /**
+   * If this content update is editorially interesting to Facebook Newstab ping their update end point.
+   *
+   * @return decision and/or ping completed successfully
+   */
   def sendFacebookNewstabPing(contentId: String): Boolean = {
     val contentPath = s"/$contentId"
     val contentWebUrl = s"https://www.theguardian.com${contentPath}"


### PR DESCRIPTION
## What does this change?

For a small set of content (travel 2020) articles send a ping to the development scope of Facebook Newstab.

Facebook Newstab behaves in a similar way to the existing AMP docroot; they want to be pinged when content is updated so that they can crawl that content.

This will allow us to investigate how this integration works without endangering the core decaching service.


## How to test

This PR will attempt the Facebook submission for a limited and known set of content (recent travel articles).
We are logging Facebooks response to see if they match the documentation.

When deployed this change will be configured with a live access token and dev scope.
We are hitting a dev setting on a live end point.


## How can we measure success?

No regression of the current Fastly and AMP integrations and collection of logs about the new Facebook responses.


## Have we considered potential risks?

- Breaking decaching.

Addressed by placing this call last in the call chain and limited it to a small set of non news content.

Config appears to be immutable once the Lambda is deployed so the roll back plan will be to redeploy the previous version of the lamdba and then roll forward with any bug fix.

- Sending the wrong content to Facebook

This is almost certainly going to kick off discussions with Facebook about what content they really want;
- live blogs?
- an update to that article from 2003?

This concern is mitigated by only using the dev scope for the proof of concept.



## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
