### PR TITLE
Clear live blog ajax files for updates which arrive as EventType. RetrievableUpdate

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -23,13 +23,16 @@ class Lambda {
       (event.itemType, event.eventType) match {
         case (ItemType.Content, EventType.Delete) =>
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
+
         case (ItemType.Content, EventType.Update) =>
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequest(s"${event.payloadId}.json", Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"${event.payloadId}.json"), config.fastlyDotcomApiKey)
+          sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
+
         case (ItemType.Content, EventType.RetrievableUpdate) =>
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
+          sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
 
         case other =>
           // for now we only send purges for content, so ignore any other events
@@ -61,6 +64,11 @@ class Lambda {
       sendAmpPingRequest(contentId)
     else
       false
+  }
+
+  private def sendFastlyPurgeRequestForLiveblogAjaxFiles(contentId: String) = {
+    val ajaxFileForContentId = s"${contentId}.json"
+    sendFastlyPurgeRequest(ajaxFileForContentId, Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(ajaxFileForContentId), config.fastlyDotcomApiKey)
   }
 
   /**

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -31,8 +31,8 @@ class Lambda {
 
         case (ItemType.Content, EventType.RetrievableUpdate) =>
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
           sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
+          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
 
         case other =>
           // for now we only send purges for content, so ignore any other events
@@ -67,8 +67,7 @@ class Lambda {
   }
 
   private def sendFastlyPurgeRequestForLiveblogAjaxFiles(contentId: String) = {
-    val ajaxFileForContentId = s"${contentId}.json"
-    sendFastlyPurgeRequest(ajaxFileForContentId, Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(ajaxFileForContentId), config.fastlyDotcomApiKey)
+    sendFastlyPurgeRequest(s"${contentId}.json", Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"${contentId}.json"), config.fastlyDotcomApiKey)
   }
 
   /**


### PR DESCRIPTION
To my untrained eye EventType.Content and EventType.RetrievableUpdate seem to be different physical representations of the same real world update.

The service which published these events (Crier) appears to sometimes convert an EventType.Update to an EventType.RetrievableUpdate. The criteria for doing this is the size of the update.
So we might have had a situation where the decache behaviours of large and small live blogs differed subtly.

This commit naively assumes that EventType.Content and EventType.RetrievableUpdate are different implementations of the same thing and should have the same effect.

I have a screen shot available to support this which I can share in house.
This logging screen shot shows LiveBlog supdate exiting Crier as EventType.Content and EventType.RetrievableUpdate.

The mapi normal content decache call might have the same differing behaviour.

## What does this change?

Increases likelyhood of live blog decaching.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
