### PR TITLE
Metrics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,15 @@ scalaVersion := "2.12.8"
 name := "fastly-cache-purger"
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 
+val awsClientVersion = "1.11.918"
 val Log4jVersion = "2.10.0"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "amazon-kinesis-client" % "1.9.1",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.339",
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
   "com.gu" %% "content-api-models-scala" % "14.2",
   "com.gu" %% "thrift-serializer" % "4.0.0",

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,11 +1,13 @@
 package com.gu.fastly
 
-import org.apache.commons.codec.digest.DigestUtils
+import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
-import okhttp3._
 import com.gu.crier.model.event.v1._
+import okhttp3._
+import org.apache.commons.codec.digest.DigestUtils
+
 import scala.collection.JavaConverters._
 
 class Lambda {
@@ -92,6 +94,9 @@ class Lambda {
     println(s"Sent $purgeType purge request for content with ID [$contentId], service with ID [$serviceId] and surrogate key [$surrogateKey]. Response from Fastly API: [${response.code}] [${response.body.string}]")
 
     val purged = response.code == 200
+
+    sendPurgeCountMetric
+
     purged
   }
   /**
@@ -114,6 +119,22 @@ class Lambda {
     println(s"Sent ping request for content with ID [$contentId]. Response from Google AMP CDN: [${response.code}] [${response.body.string}]")
 
     response.code == 204
+  }
+
+  // Count the number of purge requests we are making
+  private def sendPurgeCountMetric: Unit = {
+    import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+    val metric = new MetricDatum()
+      .withMetricName("purges")
+      .withUnit(StandardUnit.None)
+      .withValue(1)
+
+    val putMetricDataRequest = new PutMetricDataRequest().
+      withNamespace("fastly-cache-purger").
+      withMetricData(metric)
+
+    val cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient // TODO how to configure this? Then push up
+    cloudWatchClient.putMetricData(putMetricDataRequest)
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -134,8 +134,12 @@ class Lambda {
       withNamespace("fastly-cache-purger").
       withMetricData(metric)
 
-    val cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient // TODO how to configure this? Then push up
-    cloudWatchClient.putMetricData(putMetricDataRequest)
+    try {
+      cloudWatchClient.putMetricData(putMetricDataRequest)
+    } catch {
+      case t: Throwable =>
+        println("Warning; cloudwatch metrics ping failed: " + t.getMessage)
+    }
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,5 +1,6 @@
 package com.gu.fastly
 
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
@@ -14,6 +15,7 @@ class Lambda {
 
   private val config = Config.load()
   private val httpClient = new OkHttpClient()
+  private val cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient
 
   def handle(event: KinesisEvent) {
     val rawRecords: List[Record] = event.getRecords.asScala.map(_.getKinesis).toList
@@ -123,7 +125,6 @@ class Lambda {
 
   // Count the number of purge requests we are making
   private def sendPurgeCountMetric: Unit = {
-    import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
     val metric = new MetricDatum()
       .withMetricName("purges")
       .withUnit(StandardUnit.None)


### PR DESCRIPTION
## What does this change?

Attempt to introduce a metric to count the number of Fastly cache purges we are requesting.
Simple code but I'm not confident in the setup of the cloud watch client on the AWS permissions. 

My assumption is that:
 arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
implies CloudWatch access.



## How to test



## How can we measure success?

Decaches continue to function and this new count appears in CloudWatch under fastly-cache-purger / purges


## Have we considered potential risks?

The Cloudwatch client setup line could fail and prevent the execution of the Lamdba; roll back if this happens?

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
