### PR TITLE
Deduplicate batches

### DIFF
--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import scala.util.Try
 
 case class Config(fastlyDotcomServiceId: String, fastlyMapiServiceId: String, fastlyApiNextgenServiceId: String, fastlyDotcomApiKey: String, fastlyMapiApiKey: String,
-                  facebookNewsTabAccessToken: String, facebookNewsTabScope: String)
+  facebookNewsTabAccessToken: String, facebookNewsTabScope: String)
 
 object Config {
 

--- a/src/main/scala/com/gu/fastly/CrierEventDeserializer.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventDeserializer.scala
@@ -1,0 +1,15 @@
+package com.gu.fastly
+
+import com.amazonaws.services.kinesis.model.Record
+import com.gu.crier.model.event.v1.Event
+import com.gu.thrift.serializer.ThriftDeserializer
+
+import scala.util.Try
+
+object CrierEventDeserializer {
+
+  def eventFromRecord(record: Record): Try[Event] = {
+    ThriftDeserializer.deserialize(record.getData.array)(Event)
+  }
+
+}

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -7,24 +7,14 @@ import scala.util.Try
 
 object CrierEventProcessor {
 
-  def process(records: Seq[Record])(purge: Event => Boolean) = {
-    val processingResults: Iterable[Boolean] = records.flatMap { record =>
-      val event = eventFromRecord(record)
-      event.map { e =>
-        purge(e)
-      }.recover {
-        case error =>
-          println("Failed to deserialize Crier event from Kinesis record. Skipping.")
-          false
-      }.toOption
+  def process(events: Seq[Event])(purge: Event => Boolean) = {
+    val processingResults: Iterable[Boolean] = events.map { event =>
+      purge(event)
     }
+
     val purgedCount: Int = processingResults.count(_ == true)
     println(s"Successfully purged $purgedCount pieces of content")
     purgedCount
-  }
-
-  private def eventFromRecord(record: Record): Try[Event] = {
-    ThriftDeserializer.deserialize(record.getData.array)(Event)
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -30,7 +30,7 @@ class Lambda {
     println(s"Processing ${userRecords.size} records ...")
 
     val events = userRecords.asScala.flatMap { record =>
-      eventFromRecord(record) match {
+      CrierEventDeserializer.eventFromRecord(record) match {
         case Success(event) =>
           Some(event)
         case Failure(error) =>
@@ -245,10 +245,6 @@ class Lambda {
     } else {
       true
     }
-  }
-
-  private def eventFromRecord(record: Record): Try[Event] = {
-    ThriftDeserializer.deserialize(record.getData.array)(Event)
   }
 
   case class FacebookNewstabResponse(url: String, scopes: Map[String, String])

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -39,7 +39,10 @@ class Lambda {
       }
     }
 
-    CrierEventProcessor.process(events) { event =>
+    val distinctEvents = events.distinct
+    println(s"Processing ${distinctEvents.size} distinct events from batch of ${events.size} events...")
+
+    CrierEventProcessor.process(distinctEvents) { event =>
       (event.itemType, event.eventType) match {
         case (ItemType.Content, EventType.Delete) =>
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -8,12 +8,14 @@ import com.amazonaws.services.lambda.runtime.events.KinesisEvent
 import com.gu.contentapi.client.model.v1.ContentType
 import com.gu.crier.model.event.v1.EventPayload.Content
 import com.gu.crier.model.event.v1._
+import com.gu.thrift.serializer.ThriftDeserializer
 import io.circe.generic.auto._
 import io.circe.parser._
 import okhttp3._
 import org.apache.commons.codec.digest.DigestUtils
 
 import scala.collection.JavaConverters._
+import scala.util.{ Failure, Success, Try }
 
 class Lambda {
 
@@ -27,7 +29,17 @@ class Lambda {
 
     println(s"Processing ${userRecords.size} records ...")
 
-    CrierEventProcessor.process(userRecords.asScala) { event =>
+    val events = userRecords.asScala.flatMap { record =>
+      eventFromRecord(record) match {
+        case Success(event) =>
+          Some(event)
+        case Failure(error) =>
+          println("Failed to deserialize Crier event from Kinesis record. Skipping.")
+          None
+      }
+    }
+
+    CrierEventProcessor.process(events) { event =>
       (event.itemType, event.eventType) match {
         case (ItemType.Content, EventType.Delete) =>
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
@@ -37,7 +49,7 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
           sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey, contentType)
-          //sendFacebookNewstabPing(event.payloadId)
+        //sendFacebookNewstabPing(event.payloadId)
 
         case other =>
           // for now we only send purges for content, so ignore any other events
@@ -230,6 +242,10 @@ class Lambda {
     } else {
       true
     }
+  }
+
+  private def eventFromRecord(record: Record): Try[Event] = {
+    ThriftDeserializer.deserialize(record.getData.array)(Event)
   }
 
   case class FacebookNewstabResponse(url: String, scopes: Map[String, String])


### PR DESCRIPTION
## What does this change?

Before processing the deserialised Crier Events in an arriving batch deserialise the entire batch and filter for duplicates.

Anecdotally this could reduce the number of sight calls we make by half (metrics available on request).
Additional some outlying batches are almost entire duplicates.

This change trades some upfront memory usage (deserialising the entire collection) for considerably less off site calls.

This is a tactical change to filter duplicate updates at our outermost edge while we address the underlying reasons for these dupilicates.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Fastly decache request metrics should show a marked decrease.


## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Representative 5 minute average percentage of unique content ids in batches.

<img width="701" alt="dupes" src="https://user-images.githubusercontent.com/150238/102783779-604f5f00-4393-11eb-9458-b045dad3780e.png">
