### PR TITLE
Upgrade content model

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "14.2",
+  "com.gu" %% "content-api-models-scala" % "15.9.8",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -19,11 +19,6 @@ object CrierEventProcessor {
       }
     }
 
-    // During initial testing of model update fail the lambda if there are deserialization failures.
-    if (crierEvents.size < records.size) {
-      throw new RuntimeException("Rejecting batch due to deserialization errors")
-    }
-
     crierEvents.map { event =>
       purge(event)
     }

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -19,6 +19,11 @@ object CrierEventProcessor {
       }
     }
 
+    // During initial testing of model update fail the lambda if there are deserialization failures.
+    if (crierEvents.size < records.size) {
+      throw new RuntimeException("Rejecting batch due to deserialization errors")
+    }
+
     crierEvents.map { event =>
       purge(event)
     }

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -14,7 +14,7 @@ object CrierEventProcessor {
         purge(e)
       }.recover {
         case error =>
-          println("Failed to deserialize Crier event from Kinesis record. Skipping.")
+          println("Failed to deserialize Crier event from Kinesis record. Skipping: " + error.getMessage)
           false
       }.toOption
     }

--- a/src/test/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/test/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -1,14 +1,17 @@
 package com.gu.fastly
 
 import com.amazonaws.services.kinesis.model.Record
-import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType, ItemType, RetrievableContent }
+import com.gu.contentapi.client.model.v1.ContentType.Article
+import com.gu.crier.model.event.v1.{Event, EventPayload, EventType, ItemType, RetrievableContent}
 import com.gu.thrift.serializer._
+
 import java.nio.ByteBuffer
-import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
+import org.scalatest.{MustMatchers, OneInstancePerTest, WordSpecLike}
 
 class CrierEventProcessorSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
 
   "Crier Event Processor must" must {
+
     val event = Event(
       payloadId = "1234567890",
       eventType = EventType.Update,
@@ -18,7 +21,9 @@ class CrierEventProcessorSpec extends WordSpecLike with MustMatchers with OneIns
         id = "0987654321",
         capiUrl = "http://www.theguardian.com/",
         lastModifiedDate = Some(8888888888L),
-        internalRevision = Some(444444)
+        internalRevision = Some(444444),
+        contentType = Some(Article),
+        aliasPaths = Some(Seq("123", "abc"))
       )))
     )
 


### PR DESCRIPTION
## What does this change?

Level ups the content model from 14.2 to latest 15.9.8.
We are expecting additional fields on RetrieveableUpdate.

When this update was attempted as part of a feature PR it resulted in deserialisation errors.
That is why we're now attempting this as a standalone PR.


## How to test

No code Lambda. Deploy to live while watching for:
- Continues to log "Sent soft purge"
- Does not log "Failed to"

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Deserialization errors stoop cache purges.
Hence the temporary hard failure rather than the silent drop.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
