### PR TITLE
Restore reverted purge content type dimension

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -150,6 +150,7 @@ class Lambda {
 
     triedContentType match {
       case Success(value) =>
+        println("Event content type is: " + value)
         value
       case Failure(error) =>
         println("Failed to determine event content type; returning None: " + error.getMessage)

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,10 +1,12 @@
 package com.gu.fastly
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
-import com.amazonaws.services.cloudwatch.model.{MetricDatum, PutMetricDataRequest, StandardUnit}
+import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
+import com.gu.contentapi.client.model.v1.ContentType
+import com.gu.crier.model.event.v1.EventPayload.Content
 import com.gu.crier.model.event.v1._
 import io.circe.generic.auto._
 import io.circe.parser._
@@ -30,16 +32,11 @@ class Lambda {
         case (ItemType.Content, EventType.Delete) =>
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
 
-        case (ItemType.Content, EventType.Update) =>
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
-          //sendFacebookNewstabPing(event.payloadId)
-
-        case (ItemType.Content, EventType.RetrievableUpdate) =>
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
-          sendFastlyPurgeRequestForLiveblogAjaxFiles(event.payloadId)
-          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey)
+        case (ItemType.Content, EventType.Update | EventType.RetrievableUpdate) =>
+          val contentType = extractUpdateContentType(event)
+          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
+          sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)
+          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey, contentType)
           //sendFacebookNewstabPing(event.payloadId)
 
         case other =>
@@ -74,8 +71,8 @@ class Lambda {
       false
   }
 
-  private def sendFastlyPurgeRequestForLiveblogAjaxFiles(contentId: String) = {
-    sendFastlyPurgeRequest(s"${contentId}.json", Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"${contentId}.json"), config.fastlyDotcomApiKey)
+  private def sendFastlyPurgeRequestForAjaxFile(contentId: String, contentType: Option[ContentType]) = {
+    sendFastlyPurgeRequest(s"${contentId}.json", Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"${contentId}.json"), config.fastlyDotcomApiKey, contentType)
   }
 
   /**
@@ -83,7 +80,7 @@ class Lambda {
    *
    * @return whether a piece of content was purged or not
    */
-  def sendFastlyPurgeRequest(contentId: String, purgeType: PurgeType, serviceId: String, surrogateKey: String, fastlyApiKey: String): Boolean = {
+  def sendFastlyPurgeRequest(contentId: String, purgeType: PurgeType, serviceId: String, surrogateKey: String, fastlyApiKey: String, contentType: Option[ContentType] = None): Boolean = {
     val url = s"https://api.fastly.com/service/$serviceId/purge/$surrogateKey"
 
     val requestBuilder = new Request.Builder()
@@ -101,7 +98,7 @@ class Lambda {
 
     val purged = response.code == 200
 
-    sendPurgeCountMetric
+    sendPurgeCountMetric(contentType)
 
     purged
   }
@@ -127,11 +124,34 @@ class Lambda {
     response.code == 204
   }
 
+  private def extractUpdateContentType(event: Event): Option[ContentType] = {
+    // An Update event should contain a Content payload with a content type.
+    // A RetrievableContent event contains a content type hint and a link to the full content
+    event.payload.flatMap { payload =>
+      payload.containedValue() match {
+        case content: Content =>
+          Some(content.content.`type`)
+        case retrievableContent: RetrievableContent =>
+          retrievableContent.contentType
+      }
+    }
+  }
+
   // Count the number of purge requests we are making
-  private def sendPurgeCountMetric: Unit = {
+  private def sendPurgeCountMetric(contentType: Option[ContentType]): Unit = {
+    import scala.collection.JavaConverters._
+    val contentTypeDimension = contentType.map { ct =>
+      new Dimension()
+        .withName("contentType")
+        .withValue(ct.name);
+    }
+
+    val dimensions = Seq(contentTypeDimension).flatten
+
     val metric = new MetricDatum()
       .withMetricName("purges")
       .withUnit(StandardUnit.None)
+      .withDimensions(dimensions.asJavaCollection)
       .withValue(1)
 
     val putMetricDataRequest = new PutMetricDataRequest().

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,12 +1,11 @@
 package com.gu.fastly
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
-import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
 import com.gu.contentapi.client.model.v1.ContentType
-import com.gu.crier.model.event.v1.EventPayload.Content
 import com.gu.crier.model.event.v1._
 import io.circe.generic.auto._
 import io.circe.parser._
@@ -14,7 +13,7 @@ import okhttp3._
 import org.apache.commons.codec.digest.DigestUtils
 
 import scala.collection.JavaConverters._
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 class Lambda {
 
@@ -137,13 +136,10 @@ class Lambda {
     // A RetrievableContent event contains a content type hint and a link to the full content
     val triedContentType = Try {
       event.payload.flatMap { payload =>
-        payload.containedValue() match {
-          case content: Content =>
-            Some(content.content.`type`)
-          case retrievableContent: RetrievableContent =>
-            retrievableContent.contentType
-          case _ =>
-            None
+        payload match {
+          case EventPayload.Content(content) => Some(content.`type`)
+          case EventPayload.RetrievableContent(retrievableContent) => retrievableContent.contentType
+          case _ => None
         }
       }
     }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -32,7 +32,14 @@ class Lambda {
         case (ItemType.Content, EventType.Delete) =>
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
 
-        case (ItemType.Content, EventType.Update | EventType.RetrievableUpdate) =>
+        case (ItemType.Content, EventType.Update) =>
+          val contentType = extractUpdateContentType(event)
+          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
+          sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)
+          sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey, contentType)
+          //sendFacebookNewstabPing(event.payloadId)
+
+        case (ItemType.Content, EventType.RetrievableUpdate) =>
           val contentType = extractUpdateContentType(event)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
           sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)


### PR DESCRIPTION
This reverts commit caa6ccc7d8038f0190700635c476c07cda4ef863, reversing
changes made to ad8ea3685e1210bd2d265fe1dcb52bd7dfc5b601.

## What does this change?

Reverts the revert of the content type metric (PR #26)

Additionally fixes incomplete match on event payload type.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
