### PR TITLE
Restore deduplication of purge requests

### DIFF
--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import scala.util.Try
 
 case class Config(fastlyDotcomServiceId: String, fastlyMapiServiceId: String, fastlyApiNextgenServiceId: String, fastlyDotcomApiKey: String, fastlyMapiApiKey: String,
-                  facebookNewsTabAccessToken: String, facebookNewsTabScope: String)
+  facebookNewsTabAccessToken: String, facebookNewsTabScope: String)
 
 object Config {
 

--- a/src/main/scala/com/gu/fastly/CrierEventDeserializer.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventDeserializer.scala
@@ -1,0 +1,15 @@
+package com.gu.fastly
+
+import com.amazonaws.services.kinesis.model.Record
+import com.gu.crier.model.event.v1.Event
+import com.gu.thrift.serializer.ThriftDeserializer
+
+import scala.util.Try
+
+object CrierEventDeserializer {
+
+  def eventFromRecord(record: Record): Try[Event] = {
+    ThriftDeserializer.deserialize(record.getData.array)(Event)
+  }
+
+}

--- a/src/main/scala/com/gu/fastly/CrierEventDeserializer.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventDeserializer.scala
@@ -1,13 +1,26 @@
 package com.gu.fastly
 
+import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.crier.model.event.v1.Event
 import com.gu.thrift.serializer.ThriftDeserializer
 
-import scala.util.Try
+import scala.collection.mutable
+import scala.util.{ Failure, Success, Try }
 
 object CrierEventDeserializer {
 
+  def deserializeEvents(scala: mutable.Buffer[UserRecord]): Seq[Event] = {
+    scala.flatMap { record =>
+      CrierEventDeserializer.eventFromRecord(record) match {
+        case Success(event) =>
+          Some(event)
+        case Failure(error) =>
+          println("Failed to deserialize Crier event from Kinesis record. Skipping.")
+          None
+      }
+    }
+  }
   def eventFromRecord(record: Record): Try[Event] = {
     ThriftDeserializer.deserialize(record.getData.array)(Event)
   }

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -1,24 +1,10 @@
 package com.gu.fastly
 
-import com.amazonaws.services.kinesis.model.Record
 import com.gu.crier.model.event.v1.Event
-import com.gu.thrift.serializer.ThriftDeserializer
-
-import scala.util.{Failure, Success, Try}
 
 object CrierEventProcessor {
 
-  def process(records: Seq[Record])(purge: Event => Boolean) = {
-    val crierEvents = records.flatMap { record =>
-      eventFromRecord(record) match {
-        case Success(event) =>
-          Some(event)
-        case Failure(error) =>
-          println("Failed to deserialize Crier event from Kinesis record. Skipping: " + error.getMessage)
-          None
-      }
-    }
-
+  def process(crierEvents: Seq[Event])(purge: Event => Boolean) = {
     crierEvents.map { event =>
       purge(event)
     }
@@ -26,10 +12,6 @@ object CrierEventProcessor {
     val purgedCount: Int = crierEvents.size
     println(s"Successfully purged $purgedCount pieces of content")
     purgedCount
-  }
-
-  private def eventFromRecord(record: Record): Try[Event] = {
-    ThriftDeserializer.deserialize(record.getData.array)(Event)
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -29,9 +29,6 @@ class Lambda {
 
     val distinctEvents = UpdateDeduplicator.filterAndDeduplicateContentEvents(events)
     println(s"Processing ${distinctEvents.size} distinct content events from batch of ${events.size} events...")
-    if (distinctEvents.size < events.size) {
-      println("Deduplicated (" + distinctEvents.map(_.payloadId).mkString(", ") + ") to: (" + events.map(_.payloadId).mkString(", ") + ")")
-    }
 
     CrierEventProcessor.process(distinctEvents) { event =>
       (event.itemType, event.eventType) match {

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -29,6 +29,9 @@ class Lambda {
 
     val distinctEvents = UpdateDeduplicator.filterAndDeduplicateContentEvents(events)
     println(s"Processing ${distinctEvents.size} distinct content events from batch of ${events.size} events...")
+    if (distinctEvents.size < events.size) {
+      println("Deduplicated (" + distinctEvents.map(_.payloadId).mkString(", ") + ") to: (" + events.map(_.payloadId).mkString(", ") + ")")
+    }
 
     CrierEventProcessor.process(distinctEvents) { event =>
       (event.itemType, event.eventType) match {

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -27,7 +27,7 @@ class Lambda {
     println(s"Processing ${userRecords.size} records ...")
     val events = CrierEventDeserializer.deserializeEvents(userRecords.asScala)
 
-    val distinctEvents = events.distinct
+    val distinctEvents = UpdateDeduplicator.filterAndDeduplicateContentEvents(events)
     println(s"Processing ${distinctEvents.size} distinct events from batch of ${events.size} events...")
 
     CrierEventProcessor.process(distinctEvents) { event =>

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -28,7 +28,7 @@ class Lambda {
     val events = CrierEventDeserializer.deserializeEvents(userRecords.asScala)
 
     val distinctEvents = UpdateDeduplicator.filterAndDeduplicateContentEvents(events)
-    println(s"Processing ${distinctEvents.size} distinct events from batch of ${events.size} events...")
+    println(s"Processing ${distinctEvents.size} distinct content events from batch of ${events.size} events...")
 
     CrierEventProcessor.process(distinctEvents) { event =>
       (event.itemType, event.eventType) match {

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -13,6 +13,7 @@ import okhttp3._
 import org.apache.commons.codec.digest.DigestUtils
 
 import scala.collection.JavaConverters._
+import scala.util.{ Failure, Success, Try }
 
 class Lambda {
 
@@ -26,7 +27,20 @@ class Lambda {
 
     println(s"Processing ${userRecords.size} records ...")
 
-    CrierEventProcessor.process(userRecords.asScala) { event =>
+    val events = userRecords.asScala.flatMap { record =>
+      CrierEventDeserializer.eventFromRecord(record) match {
+        case Success(event) =>
+          Some(event)
+        case Failure(error) =>
+          println("Failed to deserialize Crier event from Kinesis record. Skipping.")
+          None
+      }
+    }
+
+    val distinctEvents = events.distinct
+    println(s"Processing ${distinctEvents.size} distinct events from batch of ${events.size} events...")
+
+    CrierEventProcessor.process(distinctEvents) { event =>
       (event.itemType, event.eventType) match {
         case (ItemType.Content, EventType.Delete) =>
           sendFastlyPurgeRequestAndAmpPingRequest(event.payloadId, Hard, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey)
@@ -43,7 +57,7 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
           sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey, contentType)
-        //sendFacebookNewstabPing(event.payloadId)
+          //sendFacebookNewstabPing(event.payloadId)
 
         case other =>
           // for now we only send purges for content, so ignore any other events

--- a/src/main/scala/com/gu/fastly/UpdateDeduplicator.scala
+++ b/src/main/scala/com/gu/fastly/UpdateDeduplicator.scala
@@ -1,0 +1,29 @@
+package com.gu.fastly
+
+import com.gu.crier.model.event.v1.{ Event, EventType, ItemType }
+
+object UpdateDeduplicator {
+
+  // Filter for Content events then deduplicate updates by content id
+  def filterAndDeduplicateContentEvents(events: Seq[Event]): Seq[Event] = {
+    // This lambda only processes Content events
+    val contentEvents = events.filter(_.itemType == ItemType.Content)
+
+    val updateEvents = contentEvents.filter(event =>
+      event.eventType match {
+        case EventType.Update => true
+        case EventType.RetrievableUpdate => true
+        case _ => false
+      })
+
+    // Anything which is an update can be past on
+    val otherContentEvents = contentEvents.diff(updateEvents)
+
+    // Map by payload id (which is a content id) to merge duplicates
+    val deduplicatedContentUpdateEvents = updateEvents.map(updateEvent =>
+      updateEvent.payloadId -> updateEvent).toMap.values.toSeq
+
+    otherContentEvents ++ deduplicatedContentUpdateEvents
+  }
+
+}

--- a/src/main/scala/com/gu/fastly/UpdateDeduplicator.scala
+++ b/src/main/scala/com/gu/fastly/UpdateDeduplicator.scala
@@ -23,6 +23,10 @@ object UpdateDeduplicator {
     val deduplicatedContentUpdateEvents = updateEvents.map(updateEvent =>
       updateEvent.payloadId -> updateEvent).toMap.values.toSeq
 
+    if (deduplicatedContentUpdateEvents.size < updateEvents.size) {
+      println("Deduplicated content update events (" + events.map(_.payloadId).mkString(", ") + ") to: (" + deduplicatedContentUpdateEvents.map(_.payloadId).mkString(", ") + ")")
+    }
+
     otherContentEvents ++ deduplicatedContentUpdateEvents
   }
 

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -8,10 +8,11 @@ import com.gu.thrift.serializer._
 import java.nio.ByteBuffer
 import org.scalatest.{MustMatchers, OneInstancePerTest, WordSpecLike}
 
-class CrierEventProcessorSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
+import scala.util.Success
 
-  "Crier Event Processor must" must {
+class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
 
+  "Deserializer must" must {
     val event = Event(
       payloadId = "1234567890",
       eventType = EventType.Update,
@@ -29,14 +30,14 @@ class CrierEventProcessorSpec extends WordSpecLike with MustMatchers with OneIns
 
     "properly deserialize a compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, Some(ZstdType), None)
-      val record = new Record().withData(ByteBuffer.wrap(bytes))
-      CrierEventProcessor.process(List(record))(event => true) mustEqual 1
+      val compressedEventRecord = new Record().withData(ByteBuffer.wrap(bytes))
+      CrierEventDeserializer.eventFromRecord(compressedEventRecord) mustEqual Success(event)
     }
 
     "properly deserialize a non-compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, None, None)
-      val record = new Record().withData(ByteBuffer.wrap(bytes))
-      CrierEventProcessor.process(List(record))(event => true) mustEqual 1
+      val eventRecord = new Record().withData(ByteBuffer.wrap(bytes))
+      CrierEventDeserializer.eventFromRecord(eventRecord) mustEqual Success(event)
     }
   }
 }

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -2,11 +2,11 @@ package com.gu.fastly
 
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.contentapi.client.model.v1.ContentType.Article
-import com.gu.crier.model.event.v1.{Event, EventPayload, EventType, ItemType, RetrievableContent}
+import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType, ItemType, RetrievableContent }
 import com.gu.thrift.serializer._
 
 import java.nio.ByteBuffer
-import org.scalatest.{MustMatchers, OneInstancePerTest, WordSpecLike}
+import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
 
 import scala.util.Success
 

--- a/src/test/scala/com/gu/fastly/UpdateDeduplicatorSpec.scala
+++ b/src/test/scala/com/gu/fastly/UpdateDeduplicatorSpec.scala
@@ -1,0 +1,72 @@
+package com.gu.fastly
+
+import com.amazonaws.services.kinesis.model.Record
+import com.gu.contentapi.client.model.v1.ContentType.{Article, Liveblog}
+import com.gu.crier.model.event.v1._
+import com.gu.thrift.serializer._
+import org.scalatest.{MustMatchers, OneInstancePerTest, WordSpecLike}
+
+import java.nio.ByteBuffer
+import scala.util.Success
+
+class UpdateDeduplicatorSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
+
+  "UpdatesDeduplicator must" must {
+    val updateContentEvent = Event(
+      payloadId = "123",
+      eventType = EventType.Update,
+      itemType = ItemType.Content,
+      dateTime = 100000000L,
+      payload = Some(EventPayload.RetrievableContent(RetrievableContent(
+        id = "0987654321",
+        capiUrl = "http://www.theguardian.com/",
+        lastModifiedDate = Some(8888888888L),
+        internalRevision = Some(444444),
+        contentType = Some(Article),
+        aliasPaths = Some(Seq("123", "abc"))
+      ))))
+
+    val anotherUpdateContentEvent = Event(
+      payloadId = "456",
+      eventType = EventType.Update,
+      itemType = ItemType.Content,
+      dateTime = 100000000L,
+      payload = Some(EventPayload.RetrievableContent(RetrievableContent(
+        id = "0987654321",
+        capiUrl = "http://www.theguardian.com/",
+        lastModifiedDate = Some(8888888888L),
+        internalRevision = Some(444444),
+        contentType = Some(Liveblog),
+      ))))
+
+    val deleteContentEvent = Event(
+      payloadId = "789",
+      eventType = EventType.Delete,
+      itemType = ItemType.Content,
+      dateTime = 100000000L,
+      payload = Some(EventPayload.RetrievableContent(RetrievableContent(
+        id = "0987654321",
+        capiUrl = "http://www.theguardian.com/",
+        lastModifiedDate = Some(8888888888L),
+        internalRevision = Some(444444),
+        contentType = Some(Liveblog),
+      ))))
+
+    "pass delete events for processing" in {
+      val deduplicated = UpdateDeduplicator.filterAndDeduplicateContentEvents(Seq(deleteContentEvent))
+      println(deduplicated)
+
+      deduplicated.size mustEqual 1
+      deduplicated mustEqual Seq(deleteContentEvent)
+    }
+
+    "deduplicate update events" in {
+      val batchWithDuplicates = Seq(deleteContentEvent, updateContentEvent, updateContentEvent, anotherUpdateContentEvent)
+
+      val deduplicated = UpdateDeduplicator.filterAndDeduplicateContentEvents(batchWithDuplicates)
+      deduplicated.foreach(e => println(e.payloadId))
+      deduplicated.size mustEqual 3
+      deduplicated mustEqual Seq(deleteContentEvent, updateContentEvent, anotherUpdateContentEvent)
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

Restores reverted #37 (deduplication of purge requests in a given Lambda batch)

The big change in #37 is the separation of the deserialisation of Kinesis events from the processing of Crier Events.

This PR restores than change and goes on correctly duplicate at the Event level.

The UpdateDeduplicator class and it's test have been introduce to keep the deduplications decisions in an isolated testable place as this was begin to get non trivial.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
