### PR TITLE
Reinstate facebook proof of concept call

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -226,9 +226,11 @@ class Lambda {
         // Soft evaluate the Facebook response
         // Their documentation does not specifically mention response codes.
         // Lets evaluate and log our interpretation of the response for now
+        val responseBody = response.body.string()
+
         val wasSuccessful = response.code match {
           case 200 =>
-            decode[FacebookNewstabResponse](response.body.string()).fold({ error =>
+            decode[FacebookNewstabResponse](responseBody).fold({ error =>
               println("Failed to parse Facebook Newstab response: " + error.getMessage)
               false
             }, { facebookResponse =>
@@ -240,7 +242,7 @@ class Lambda {
         }
 
         println(s"Sent Facebook Newstab ping request for content with url [$contentWebUrl]. " +
-          s"Response from Facebook: [${response.code}] [${response.body.string}]. " +
+          s"Response from Facebook: [${response.code}] [${responseBody}]. " +
           s"Was successful: [$wasSuccessful]")
 
       } catch {

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -22,8 +22,8 @@ class Lambda {
   private val httpClient = new OkHttpClient()
   private val facebookHttpClient = {
     new OkHttpClient.Builder()
-      .connectTimeout(5000, TimeUnit.MILLISECONDS)
-      .readTimeout(5000, TimeUnit.MILLISECONDS)
+      .connectTimeout(10000, TimeUnit.MILLISECONDS)
+      .readTimeout(10000, TimeUnit.MILLISECONDS)
       .build()
   }
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,7 +1,7 @@
 package com.gu.fastly
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
-import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
+import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
@@ -13,12 +13,20 @@ import okhttp3._
 import org.apache.commons.codec.digest.DigestUtils
 
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 import scala.collection.JavaConverters._
 
 class Lambda {
 
   private val config = Config.load()
   private val httpClient = new OkHttpClient()
+  private val facebookHttpClient = {
+    new OkHttpClient.Builder()
+      .connectTimeout(1000, TimeUnit.MILLISECONDS)
+      .readTimeout(1000, TimeUnit.MILLISECONDS)
+      .build()
+  }
+
   private val cloudWatchClient = AmazonCloudWatchClientBuilder.defaultClient
 
   def handle(event: KinesisEvent) {
@@ -213,7 +221,7 @@ class Lambda {
           .post(EmptyJsonBody)
           .build()
 
-        val response = httpClient.newCall(request).execute()
+        val response = facebookHttpClient.newCall(request).execute()
 
         // Soft evaluate the Facebook response
         // Their documentation does not specifically mention response codes.

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -49,14 +49,14 @@ class Lambda {
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
           sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey, contentType)
-        //sendFacebookNewstabPing(event.payloadId)
+          sendFacebookNewstabPing(event.payloadId)
 
         case (ItemType.Content, EventType.RetrievableUpdate) =>
           val contentType = extractUpdateContentType(event)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyDotcomServiceId, makeDotcomSurrogateKey(event.payloadId), config.fastlyDotcomApiKey, contentType)
           sendFastlyPurgeRequestForAjaxFile(event.payloadId, contentType)
           sendFastlyPurgeRequest(event.payloadId, Soft, config.fastlyMapiServiceId, makeMapiSurrogateKey(event.payloadId), config.fastlyMapiApiKey, contentType)
-        //sendFacebookNewstabPing(event.payloadId)
+          sendFacebookNewstabPing(event.payloadId)
 
         case other =>
           // for now we only send purges for content, so ignore any other events

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -22,8 +22,8 @@ class Lambda {
   private val httpClient = new OkHttpClient()
   private val facebookHttpClient = {
     new OkHttpClient.Builder()
-      .connectTimeout(1000, TimeUnit.MILLISECONDS)
-      .readTimeout(1000, TimeUnit.MILLISECONDS)
+      .connectTimeout(5000, TimeUnit.MILLISECONDS)
+      .readTimeout(5000, TimeUnit.MILLISECONDS)
       .build()
   }
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -22,8 +22,8 @@ class Lambda {
   private val httpClient = new OkHttpClient()
   private val facebookHttpClient = {
     new OkHttpClient.Builder()
-      .connectTimeout(10000, TimeUnit.MILLISECONDS)
-      .readTimeout(10000, TimeUnit.MILLISECONDS)
+      .connectTimeout(5000, TimeUnit.MILLISECONDS)
+      .readTimeout(5000, TimeUnit.MILLISECONDS)
       .build()
   }
 


### PR DESCRIPTION
## What does this change?

Reinstates proof of concept Facebook newstab ping for travel articles.

- Isolates these calls in a separate http client with very limited timeouts.
- Runtime exception try block around the call (as OkHttp client seems to have Java roots)

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

The last attempt at this caused the Lambda to reach it's 15 second time out and jam the queue.
The root cause if these was believed to be multiple repeated calls to the slow Facebook endpoint with in the same Lambda batch.
The risk of this has since been reduced by:
- The batch deduplication work should ensure 1 Facebook call per unique travel article.
- Explicit quick fail timeouts on these calls.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
