### PR TITLE
Limit number of Facebook Newtab pings in a given batch

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -38,7 +38,7 @@ Resources:
       Runtime: java8
       Handler: com.gu.fastly.Lambda::handle
       MemorySize: 512
-      Timeout: 15
+      Timeout: 30
       Role: !GetAtt LambdaRole.Arn
       Tags:
         - Key: Stack

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -76,9 +76,11 @@ class Lambda {
       .filter(event => contentIsInterestingToFacebookNewstab(event.payloadId))
       .take(maximumFacebookPingsPerBatch) // Limit the volume of pings during proof of concept
 
-    println("Sending Facebook pings for " + facebookNewstabUpdates.size + " content ids")
-    facebookNewstabUpdates.map { event =>
-      sendFacebookNewstabPing(event.payloadId)
+    if (facebookNewstabUpdates.nonEmpty) {
+      println("Sending Facebook pings for " + facebookNewstabUpdates.size + " content ids")
+      facebookNewstabUpdates.map { event =>
+        sendFacebookNewstabPing(event.payloadId)
+      }
     }
 
     println(s"Finished.")


### PR DESCRIPTION
## What does this change?

To prevent the Facebook Newstab proof of concept blocking the Lambda by making a large number of slow off site calls,
isolate these calls and limit their number for a given batch.

Discard excessive updates.

This PR will be accompanied by an increase in the maximum run time for this Lambda to accomodate a worse case for these calls.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
