### PR TITLE
Remove deleted content from Facebook Newstab by making a DENYLIST request.

### DIFF
--- a/src/main/scala/com/gu/fastly/UpdateDeduplicator.scala
+++ b/src/main/scala/com/gu/fastly/UpdateDeduplicator.scala
@@ -9,25 +9,38 @@ object UpdateDeduplicator {
     // This lambda only processes Content events
     val contentEvents = events.filter(_.itemType == ItemType.Content)
 
-    val updateEvents = contentEvents.filter(event =>
+    val contentUpdateEvents = contentEvents.filter(event =>
       event.eventType match {
         case EventType.Update => true
         case EventType.RetrievableUpdate => true
         case _ => false
       })
 
+    val contentDeleteEvents = contentEvents.filter(event =>
+      event.eventType match {
+        case EventType.Delete => true
+        case _ => false
+      })
+
     // Anything which is an update can be past on
-    val otherContentEvents = contentEvents.diff(updateEvents)
+    val otherContentEvents = contentEvents.diff(contentUpdateEvents ++ contentDeleteEvents)
 
     // Map by payload id (which is a content id) to merge duplicates
-    val deduplicatedContentUpdateEvents = updateEvents.map(updateEvent =>
-      updateEvent.payloadId -> updateEvent).toMap.values.toSeq
-
-    if (deduplicatedContentUpdateEvents.size < updateEvents.size) {
-      println("Deduplicated content update events (" + events.map(_.payloadId).mkString(", ") + ") to: (" + deduplicatedContentUpdateEvents.map(_.payloadId).mkString(", ") + ")")
+    val deduplicatedContentUpdateEvents = duplicateByPayloadId(contentUpdateEvents)
+    if (deduplicatedContentUpdateEvents.size < contentUpdateEvents.size) {
+      println("Deduplicated content update events (" + contentUpdateEvents.map(_.payloadId).mkString(", ") + ") to: (" + deduplicatedContentUpdateEvents.map(_.payloadId).mkString(", ") + ")")
     }
 
-    otherContentEvents ++ deduplicatedContentUpdateEvents
+    val deduplicatedContentDeleteEvents = duplicateByPayloadId(contentDeleteEvents)
+    if (deduplicatedContentDeleteEvents.size < contentDeleteEvents.size) {
+      println("Deduplicated content delete events (" + contentDeleteEvents.map(_.payloadId).mkString(", ") + ") to: (" + deduplicatedContentDeleteEvents.map(_.payloadId).mkString(", ") + ")")
+    }
+
+    otherContentEvents ++ deduplicatedContentDeleteEvents ++ deduplicatedContentUpdateEvents
+  }
+
+  private def duplicateByPayloadId(events: Seq[Event]): Seq[Event] = {
+    events.map(event => event.payloadId -> event).toMap.values.toSeq
   }
 
 }

--- a/src/test/scala/com/gu/fastly/UpdateDeduplicatorSpec.scala
+++ b/src/test/scala/com/gu/fastly/UpdateDeduplicatorSpec.scala
@@ -54,7 +54,15 @@ class UpdateDeduplicatorSpec extends WordSpecLike with MustMatchers with OneInst
 
     "pass delete events for processing" in {
       val deduplicated = UpdateDeduplicator.filterAndDeduplicateContentEvents(Seq(deleteContentEvent))
-      println(deduplicated)
+
+      deduplicated.size mustEqual 1
+      deduplicated mustEqual Seq(deleteContentEvent)
+    }
+
+    "deduplicate delete events" in {
+      val batchWithDuplicateDeletes = Seq(deleteContentEvent, deleteContentEvent)
+
+      val deduplicated = UpdateDeduplicator.filterAndDeduplicateContentEvents(batchWithDuplicateDeletes)
 
       deduplicated.size mustEqual 1
       deduplicated mustEqual Seq(deleteContentEvent)
@@ -64,9 +72,10 @@ class UpdateDeduplicatorSpec extends WordSpecLike with MustMatchers with OneInst
       val batchWithDuplicates = Seq(deleteContentEvent, updateContentEvent, updateContentEvent, anotherUpdateContentEvent)
 
       val deduplicated = UpdateDeduplicator.filterAndDeduplicateContentEvents(batchWithDuplicates)
-      deduplicated.foreach(e => println(e.payloadId))
+
       deduplicated.size mustEqual 3
       deduplicated mustEqual Seq(deleteContentEvent, updateContentEvent, anotherUpdateContentEvent)
     }
+
   }
 }


### PR DESCRIPTION
## What does this change?

When we remove an article attempt to remove it from Facebook Newstab by making a DENYLIST request.

This will add the article to the News Tab denylist hiding the article from the News Tab.
"Denylisting only affects articles in the News Tab. Articles will still be visible on other Facebook surfaces."

Limit this to content within the scope of the proof of concept. Start deduplicating Facebook related code.

Deduplicate the incoming delete content events to minimise time spent making deduplicate off site calls.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Successful DENYLIST requests will be seen in the logs.

## Have we considered potential risks?

Adds more potential offsite calls.
Exceeding the total Lambda execution time is the main risk. The chances of multiple takedowns inside the same Lambda batch during the proof of concept is low.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
