### PR TITLE
Publish notifications for successful decache request

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.9.8",
+  "com.gu" %% "content-api-models-scala" % "15.9.9-SNAPSHOT",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.9.9-SNAPSHOT",
+  "com.gu" %% "content-api-models-scala" % "15.9.9",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
   "com.gu" %% "content-api-models-scala" % "15.9.8",
   "com.gu" %% "thrift-serializer" % "4.0.0",

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -86,3 +86,8 @@ Resources:
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
+  DecachedCotentTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${App}-${Stage}-decached"
+      DisplayName: !Sub '${App}-${Stage}-Decached'

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -79,6 +79,13 @@ Resources:
                 - cloudwatch:PutMetricData
               Resource: "*"
               Effect: Allow
+        - PolicyName: AllowSNSPublish
+          PolicyDocument:
+            Statement:
+              Action:
+                - sns:Publish
+              Resource: "*"
+              Effect: Allow
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -86,7 +93,7 @@ Resources:
             Effect: Allow
             Principal:
               Service: lambda.amazonaws.com
-  DecachedCotentTopic:
+  DecachedContentTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub "${App}-${Stage}-decached"

--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import scala.util.Try
 
 case class Config(fastlyDotcomServiceId: String, fastlyMapiServiceId: String, fastlyApiNextgenServiceId: String, fastlyDotcomApiKey: String, fastlyMapiApiKey: String,
-  facebookNewsTabAccessToken: String, facebookNewsTabScope: String)
+  facebookNewsTabAccessToken: String, facebookNewsTabScope: String, decachedContentTopic: String)
 
 object Config {
 
@@ -30,8 +30,10 @@ object Config {
 
     val facebookNewsTabScope = getMandatoryConfig(properties, "facebook.newstab.scope")
 
+    val decachedContentTopic = getMandatoryConfig(properties, "decached.content.topic")
+
     Config(fastlyDotcomServiceId, fastlyMapiServiceId, fastlyGuardianAppsServiceId, fastlyDotcomApiKey, fastlyMapiApiKey,
-      facebookNewsTabAccessToken, facebookNewsTabScope)
+      facebookNewsTabAccessToken, facebookNewsTabScope, decachedContentTopic)
   }
 
   private def loadProperties(bucket: String, key: String): Try[Properties] = {

--- a/src/main/scala/com/gu/fastly/ContentDecachedEventSerializer.scala
+++ b/src/main/scala/com/gu/fastly/ContentDecachedEventSerializer.scala
@@ -1,0 +1,18 @@
+package com.gu.fastly
+
+import com.gu.fastly.model.event.v1.ContentDecachedEvent
+import org.apache.thrift.protocol.TJSONProtocol
+import org.apache.thrift.transport.TMemoryBuffer
+
+import java.nio.charset.StandardCharsets
+
+object ContentDecachedEventSerializer {
+
+  def serialize(event: ContentDecachedEvent): String = {
+    val buffer = new TMemoryBuffer(128)
+    val protocol = new TJSONProtocol(buffer)
+    event.write(protocol)
+    new String(buffer.getArray, StandardCharsets.UTF_8)
+  }
+
+}

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -4,12 +4,12 @@ import com.gu.crier.model.event.v1.Event
 
 object CrierEventProcessor {
 
-  def process(crierEvents: Seq[Event])(purge: Event => Boolean) = {
-    crierEvents.map { event =>
-      purge(event)
+  def process(crierEvents: Seq[Event])(purge: Event => Boolean): Int = {
+    val successfulPurges = crierEvents.map { event =>
+      Some(event).filter(purge)
     }
 
-    val purgedCount: Int = crierEvents.size
+    val purgedCount: Int = successfulPurges.size
     println(s"Successfully purged $purgedCount pieces of content")
     purgedCount
   }

--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -4,14 +4,14 @@ import com.gu.crier.model.event.v1.Event
 
 object CrierEventProcessor {
 
-  def process(crierEvents: Seq[Event])(purge: Event => Boolean): Int = {
-    val successfulPurges = crierEvents.map { event =>
+  def process(crierEvents: Seq[Event])(purge: Event => Boolean): Seq[Event] = {
+    val successfulPurges = crierEvents.flatMap { event =>
       Some(event).filter(purge)
     }
 
     val purgedCount: Int = successfulPurges.size
     println(s"Successfully purged $purgedCount pieces of content")
-    purgedCount
+    successfulPurges
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -142,14 +142,8 @@ class Lambda {
     RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "")
 
   private sealed trait PurgeType
-
-  private object Soft extends PurgeType {
-    override def toString = "soft"
-  }
-
-  private object Hard extends PurgeType {
-    override def toString = "hard"
-  }
+  private object Soft extends PurgeType { override def toString = "soft" }
+  private object Hard extends PurgeType { override def toString = "hard" }
 
   def makeMapiSurrogateKey(contentId: String): String = s"Item/$contentId"
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -80,16 +80,13 @@ class Lambda {
           eventType = decacheEventType
         )
         try {
-          val message = ContentDecachedEventSerializer.serialize(contentDecachedEvent)
-          println("Publishing SNS decached message for content id '" + event.payloadId + "' of length: " + message.length)
-
           val publishRequest = new PublishRequest()
           publishRequest.setTopicArn(config.decachedContentTopic)
-          publishRequest.setMessage(message)
+          publishRequest.setMessage(ContentDecachedEventSerializer.serialize(contentDecachedEvent))
           snsClient.publish(publishRequest)
         } catch {
           case t: Throwable =>
-            println("Warning; publish sns decached event failed: " + t.getMessage)
+            println("Warning; publish sns decached event failed: ${t.getMessage}")
         }
       }
     }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -70,11 +70,16 @@ class Lambda {
     // Republish events for successful deletes and updates as
     // com.gu.crier.model.event.v1.Event events thrift serialized and base64 encoded
     successfulPurges.foreach { event =>
-      val message = Base64.encodeBase64String(ThriftSerializer.serializeToBytes(event, None, None))
-      val publishRequest = new PublishRequest()
-      publishRequest.setTopicArn(config.decachedContentTopic)
-      publishRequest.setMessage(message)
-      snsClient.publish(publishRequest)
+      try {
+        val message = Base64.encodeBase64String(ThriftSerializer.serializeToBytes(event, None, None))
+        val publishRequest = new PublishRequest()
+        publishRequest.setTopicArn(config.decachedContentTopic)
+        publishRequest.setMessage(message)
+        snsClient.publish(publishRequest)
+      } catch {
+        case t: Throwable =>
+          println("Warning; publish sns decached event failed: " + t.getMessage)
+      }
     }
 
     val maximumFacebookPingsPerBatch = 3

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -69,7 +69,7 @@ class Lambda {
     // Republish events for successful deletes and updates as
     // com.gu.crier.model.event.v1.Event events thrift serialized and base64 encoded
     successfulPurges.foreach { event =>
-      val supportedDecacheEventType: Option[v1.EventType] = event.eventType match {
+      val supportedDecacheEventType = event.eventType match {
         case EventType.Update => Some(com.gu.fastly.model.event.v1.EventType.Update)
         case EventType.Delete => Some(com.gu.fastly.model.event.v1.EventType.Delete)
         case _ => None

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -72,6 +72,7 @@ class Lambda {
     successfulPurges.foreach { event =>
       try {
         val message = Base64.encodeBase64String(ThriftSerializer.serializeToBytes(event, None, None))
+        println("Publishing SNS decached message for content id '" + event.payloadId + "' of length: " + message.length)
         val publishRequest = new PublishRequest()
         publishRequest.setTopicArn(config.decachedContentTopic)
         publishRequest.setMessage(message)

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,7 +1,7 @@
 package com.gu.fastly
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
-import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
@@ -9,7 +9,6 @@ import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import com.amazonaws.services.sns.model.PublishRequest
 import com.gu.contentapi.client.model.v1.ContentType
 import com.gu.crier.model.event.v1._
-import com.gu.fastly.model.event.v1
 import io.circe.generic.auto._
 import io.circe.parser._
 import okhttp3._

--- a/src/test/scala/com/gu/fastly/ContentDecachedEventSerializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/ContentDecachedEventSerializerSpec.scala
@@ -1,0 +1,22 @@
+package com.gu.fastly
+
+import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
+
+class ContentDecachedEventSerializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
+
+  "Serializer must" must {
+
+    "serialize to a SNS compatible string based format" in {
+      val contentDecachedEvent =
+        com.gu.fastly.model.event.v1.ContentDecachedEvent(
+          contentId = "/travel/some-content",
+          eventType = com.gu.fastly.model.event.v1.EventType.Update
+        )
+
+      val serialized = ContentDecachedEventSerializer.serialize(contentDecachedEvent)
+
+      serialized must include("\"1\":{\"str\":\"/travel/some-content\"")
+    }
+
+  }
+}

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -2,12 +2,11 @@ package com.gu.fastly
 
 import com.amazonaws.services.kinesis.model.Record
 import com.gu.contentapi.client.model.v1.ContentType.Article
-import com.gu.crier.model.event.v1.{ Event, EventPayload, EventType, ItemType, RetrievableContent }
+import com.gu.crier.model.event.v1._
 import com.gu.thrift.serializer._
-
-import java.nio.ByteBuffer
 import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
 
+import java.nio.ByteBuffer
 import scala.util.Success
 
 class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {


### PR DESCRIPTION
## What does this change?

The Fastly decacher publishes SNS notifications for successful decache requests.
These allows us to move 3rd party content updated calls to separate deployables.

Specially the slow Facebook Newstab calls can  move to their own SQS and Lambda.
 
SNS messages are String bases so we're using the Thrift JSON encoding.


## How to test

I've subscribed a test SQS to this topic; it should begin to fill up with messages.
This will show that the fan out is working.


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

SNS call is wrapped in try so it will fail softly.


## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
