### PR TITLE
Migrate amp flush Private Key pick up to AmpFlusher

### DIFF
--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -3,7 +3,6 @@ package com.gu.fastly
 import java.util.Properties
 import scala.util.Try
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.util.IOUtils
 
 case class Config(
   fastlyDotcomServiceId: String,
@@ -11,8 +10,7 @@ case class Config(
   fastlyApiNextgenServiceId: String,
   fastlyDotcomApiKey: String,
   fastlyMapiApiKey: String,
-  decachedContentTopic: String,
-  ampFlusherPrivateKey: Array[Byte]
+  decachedContentTopic: String
 )
 
 object Config {
@@ -40,8 +38,7 @@ object Config {
       fastlyGuardianAppsServiceId,
       fastlyDotcomApiKey,
       fastlyMapiApiKey,
-      decachedContentTopic,
-      getAmpFlusherPrivateKey()
+      decachedContentTopic
     )
   }
 
@@ -56,11 +53,5 @@ object Config {
   private def getMandatoryConfig(config: Properties, key: String) =
     Option(config.getProperty(key)) getOrElse sys.error(s"''$key' property missing.")
 
-  private def getAmpFlusherPrivateKey(): Array[Byte] = {
-    val inputStream = s3.getObject("fastly-cache-purger-config", "amp-flusher-private-key.der").getObjectContent()
-    val key: Array[Byte] = IOUtils.toByteArray(inputStream)
-    inputStream.close()
-    key
-  }
 }
 


### PR DESCRIPTION
## What does this change?

Previous PRs: https://github.com/guardian/fastly-cache-purger/pull/50 and https://github.com/guardian/fastly-cache-purger/pull/51

This refactoring migrates the private key S3 pick up from the Fastly Config object to the AMP Flusher object. It was originally put in the Fastly config object ( https://github.com/guardian/fastly-cache-purger/pull/50 ) because the AmpFlusher object didn't exists yet ( https://github.com/guardian/fastly-cache-purger/pull/51 ).

Another change is that instead of keeping the key in memory, we now read it from disk every time a flush request is issued. This is fine because those requests are issued once in a while, so S3 latency is ok, and has the great advantage that updating the key on disk doesn't require the Lambda to be restarted. 