### PR TITLE
WIP: Getting ready for aliasPaths in Crier events

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.9.9",
+  "com.gu" %% "content-api-models-scala" % "15.9.14",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,


### PR DESCRIPTION
## What does this change?
Fires de-caching events for any `aliasPaths` that  are associated with a content update or delete - which will be included in the events raised within Crier (see https://github.com/guardian/crier/pull/120)

## How to test
Local tests passed, and these include mocked aliasPaths already so there shouldn't be any surprises. 
TODO: add a delete parse test with `aliasPaths`

## How can we measure success?
Do all the right things get de-cached? Success!

## Have we considered potential risks?
Well, de-caching _everything_ would be pretty bad. But I don't think this is likely with this change.

## Images
N/A
