### PR TITLE
Raise de-cache requests and send SNS notifications for canonical and alias paths 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.9.9",
+  "com.gu" %% "content-api-models-scala" % "15.9.14",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.9.14",
+  "com.gu" %% "content-api-models-scala" % "15.9.17",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -38,7 +38,7 @@ class Lambda {
     def jsonAliasPurge(path: String) = sendFastlyPurgeRequestForAjaxFile(path, contentType)
     def mapiAliasPurge(path: String) = sendFastlyPurgeRequest(path, purgeType, config.fastlyMapiServiceId, makeMapiSurrogateKey(path), config.fastlyMapiApiKey, contentType)
 
-    val purgesToPreform: Seq[String => Boolean] = purgeType match {
+    val purgesToPerform: Seq[String => Boolean] = purgeType match {
       case Hard => Seq(dotcomAliasPurge)
       case Soft => Seq(dotcomAliasPurge, jsonAliasPurge, mapiAliasPurge)
     }
@@ -46,7 +46,7 @@ class Lambda {
     val pathsToPurge = Seq(event.payloadId) ++ extractAliasPaths(event)
 
     pathsToPurge.flatMap { path =>
-      purgesToPreform.map(purge => purge(path))
+      purgesToPerform.map(purge => purge(path))
     }.forall(_ == true)
   }
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -100,7 +100,10 @@ class Lambda {
     // Purge AMP pages
     successfulPurges.foreach { crierEvent =>
       if (crierEvent.itemType == ItemType.Content && crierEvent.eventType == EventType.Delete) {
-        AmpFlusher.sendAmpDeleteRequest(crierEvent.payloadId)
+        val eventPaths = Seq(crierEvent.payloadId) ++ extractAliasPaths(crierEvent)
+        eventPaths.foreach { path =>
+          AmpFlusher.sendAmpDeleteRequest(path)
+        }
       }
     }
 

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -135,14 +135,6 @@ class Lambda {
     dotcomSurrogateKey
   }
 
-  // TODO: This appears to be unused - delete it?
-  //  private def sendFastlyPurgeRequestAndAmpPingRequest(contentId: String, purgeType: PurgeType, serviceId: String, surrogateKey: String, fastlyApiKey: String): Boolean = {
-  //    if (sendFastlyPurgeRequest(contentId, purgeType, serviceId, surrogateKey, fastlyApiKey))
-  //      AmpFlusher.sendAmpDeleteRequest(contentId)
-  //    else
-  //      false
-  //  }
-
   private def sendFastlyPurgeRequestForAjaxFile(contentId: String, contentType: Option[ContentType]) = {
     sendFastlyPurgeRequest(s"${contentId}.json", Soft, config.fastlyApiNextgenServiceId, makeDotcomSurrogateKey(s"${contentId}.json"), config.fastlyDotcomApiKey, contentType)
   }

--- a/src/test/scala/com/gu/fastly/ContentDecachedEventSerializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/ContentDecachedEventSerializerSpec.scala
@@ -9,7 +9,7 @@ class ContentDecachedEventSerializerSpec extends WordSpecLike with MustMatchers 
     "serialize to a SNS compatible string based format" in {
       val contentDecachedEvent =
         com.gu.fastly.model.event.v1.ContentDecachedEvent(
-          contentId = "/travel/some-content",
+          contentPath = "/travel/some-content",
           eventType = com.gu.fastly.model.event.v1.EventType.Update,
           contentType = Some(com.gu.contentapi.client.model.v1.ContentType.Liveblog)
         )


### PR DESCRIPTION
## What does this change?
This PR replaces https://github.com/guardian/fastly-cache-purger/pull/54 as this one includes some refactoring that reduces duplication and condenses the code a but.

Fires de-caching events for any `aliasPaths` that  are associated with a content update or delete - which will be included in the events raised within Crier (see https://github.com/guardian/crier/pull/120)

Also raises "content de-cached" SNS notifications for the canonical and any alias paths that were flushed out.

## How to test
Local tests passed, and these include mocked aliasPaths already so there shouldn't be any surprises. 
TODO: add a delete parse test with `aliasPaths`

## How can we measure success?
Do all the right things get de-cached? Success!

## Have we considered potential risks?
Well, de-caching _everything_ would be pretty bad. But I don't think this is likely with this change.

## Images
N/A
