### PR TITLE
Post decache take results of successful purges as input

### DIFF
--- a/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
+++ b/src/main/scala/com/gu/fastly/CrierEventProcessor.scala
@@ -4,13 +4,9 @@ import com.gu.crier.model.event.v1.Event
 
 object CrierEventProcessor {
 
-  def process(crierEvents: Seq[Event])(purge: Event => Boolean): Seq[Event] = {
-    val successfulPurges = crierEvents.flatMap { event =>
-      Some(event).filter(purge)
-    }
-
-    val purgedCount: Int = successfulPurges.size
-    println(s"Successfully purged $purgedCount pieces of content")
+  def process(crierEvents: Seq[Event])(purge: Event => Option[Decache]): Seq[Decache] = {
+    val successfulPurges = crierEvents.map(purge).flatten
+    println(s"Successfully purged ${successfulPurges.size} pieces of content")
     successfulPurges
   }
 


### PR DESCRIPTION
## What does this change?

Purge handler returns a Decache object to describe a successful purge.

 Post decache actions consume this rather than trying to infer what the purger would have done for a given Crier event.


## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
