### PR TITLE
Update CAPI models and rejig aliasPath extraction

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.9.17",
+  "com.gu" %% "content-api-models-scala" % "15.10.0",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -13,9 +13,9 @@ import java.nio.ByteBuffer
 import scala.util.Success
 
 class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
-  val dt1: DateTime = DateTime.now().minusDays(3)
-  val dt2: DateTime = DateTime.now().minusDays(2)
-  val fakeAliasPaths: Seq[AliasPath] = Seq(
+  val dt1 = DateTime.now().minusDays(3)
+  val dt2 = DateTime.now().minusDays(2)
+  val fakeAliasPaths = Seq(
     AliasPath("123", CapiDateTime(dt1.getMillis, dt1.withZone(UTC).toString())),
     AliasPath("abc", CapiDateTime(dt2.getMillis, dt2.withZone(UTC).toString()))
   )

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -7,7 +7,6 @@ import com.gu.crier.model.event.v1._
 import com.gu.thrift.serializer._
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone.UTC
-import org.joda.time.format.ISODateTimeFormat
 import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
 
 import java.nio.ByteBuffer
@@ -16,9 +15,10 @@ import scala.util.Success
 class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
   val dt1: DateTime = DateTime.now().minusDays(3)
   val dt2: DateTime = DateTime.now().minusDays(2)
-  val iso1: String = dt1.toString(ISODateTimeFormat.dateOptionalTimeParser.withZone(UTC))
-  val iso2: String = dt2.toString(ISODateTimeFormat.dateOptionalTimeParser.withZone(UTC))
-  val fakeAliasPaths: Seq[AliasPath] = Seq(AliasPath("123", CapiDateTime(dt1.getMillis, iso1)), AliasPath("abc", CapiDateTime(dt2.getMillis, iso2)))
+  val fakeAliasPaths: Seq[AliasPath] = Seq(
+    AliasPath("123", CapiDateTime(dt1.getMillis, dt1.withZone(UTC).toString())),
+    AliasPath("abc", CapiDateTime(dt2.getMillis, dt2.withZone(UTC).toString()))
+  )
 
   "Deserializer must" must {
     val event = Event(

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -1,15 +1,24 @@
 package com.gu.fastly
 
 import com.amazonaws.services.kinesis.model.Record
+import com.gu.contentapi.client.model.v1.{ AliasPath, CapiDateTime }
 import com.gu.contentapi.client.model.v1.ContentType.Article
 import com.gu.crier.model.event.v1._
 import com.gu.thrift.serializer._
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone.UTC
+import org.joda.time.format.ISODateTimeFormat
 import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
 
 import java.nio.ByteBuffer
 import scala.util.Success
 
 class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
+  val dt1: DateTime = DateTime.now().minusDays(3)
+  val dt2: DateTime = DateTime.now().minusDays(2)
+  val iso1: String = dt1.toString(ISODateTimeFormat.dateOptionalTimeParser.withZone(UTC))
+  val iso2: String = dt2.toString(ISODateTimeFormat.dateOptionalTimeParser.withZone(UTC))
+  val fakeAliasPaths: Seq[AliasPath] = Seq(AliasPath("123", CapiDateTime(dt1.getMillis, iso1)), AliasPath("abc", CapiDateTime(dt2.getMillis, iso2)))
 
   "Deserializer must" must {
     val event = Event(
@@ -23,7 +32,7 @@ class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInsta
         lastModifiedDate = Some(8888888888L),
         internalRevision = Some(444444),
         contentType = Some(Article),
-        aliasPaths = Some(Seq("123", "abc"))
+        aliasPaths = Some(fakeAliasPaths)
       )))
     )
 


### PR DESCRIPTION
## What does this change?
The update to add dates to evolved URL alias paths will cascade from Crier to the cache purger. The purger doesn't care about dates, so we'll just extract the path values.
 
## How to test
Hopefully the unit test will get upset if something isn't quite right here. Other than that, it'll be a case of keeping an eye on it during deployment.

## How can we measure success?
If nobody notices anything - SUCCESS!

## Have we considered potential risks?
De-caching may break. If this happens we'll quickly roll back.

## Images
N/A