### PR TITLE
Set ReservedConcurrentExecutions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ Fastly decaches may take time to propagate.
 When creating your SQS queue you may wish to add a delay to account for this propagation delay.
 
 
+## Lambda concurrency
 
+Lambdas in the same account default to sharing a fixed concurrency pool.
 
+To protect this Lambda from other rouge Lambdas consuming all the available shared concurrency we  set `Reserved concurrency` in the AWS console.
 
+This value should be set to at least the number of Kinesis trigger shards.
 
 
 

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -40,6 +40,7 @@ Resources:
       MemorySize: 512
       Timeout: 30
       Role: !GetAtt LambdaRole.Arn
+      ReservedConcurrentExecutions: 10
       Tags:
         - Key: Stack
           Value: !Ref Stack


### PR DESCRIPTION
To protect the decache lambda from any potential runaway lambdas in the shared concurrency pool.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
