### PR TITLE
Bump sbt to modern version and increment versions of plugins which no longer resolve

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.5.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.4")
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
 resolvers += "twitter-repo" at "https://maven.twttr.com"
-addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "4.18.0")
+addSbtPlugin("com.twitter" % "scrooge-sbt-plugin" % "21.8.0")


### PR DESCRIPTION
## What does this change?

Fixes unboxing of this project on a new machine.
Old versions of sbt plugins no longer resolve leading to an obscure Vector error when importing into an IDE.

Bump the sbt version to a modern version for good measure as well.



## How to test

Lambda with no test instance; so test method is test in production and quickly redeploy the last good build 😬 


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
