### PR TITLE
Content decached events include an event published timestamp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
-  "com.gu" %% "content-api-models-scala" % "15.10.0",
+  "com.gu" %% "content-api-models-scala" % "17.1.1",
   "com.gu" %% "thrift-serializer" % "4.0.0",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,

--- a/src/main/scala/com/gu/fastly/Config.scala
+++ b/src/main/scala/com/gu/fastly/Config.scala
@@ -12,8 +12,7 @@ case class Config(
   fastlyDotcomApiKey: String,
   fastlyMapiApiKey: String,
   decachedContentTopic: String,
-  ampFlusherPrivateKey: Array[Byte]
-)
+  ampFlusherPrivateKey: Array[Byte])
 
 object Config {
 
@@ -41,8 +40,7 @@ object Config {
       fastlyDotcomApiKey,
       fastlyMapiApiKey,
       decachedContentTopic,
-      getAmpFlusherPrivateKey()
-    )
+      getAmpFlusherPrivateKey())
   }
 
   private def loadProperties(bucket: String, key: String): Try[Properties] = {

--- a/src/main/scala/com/gu/fastly/ContentDecachedEventSerializer.scala
+++ b/src/main/scala/com/gu/fastly/ContentDecachedEventSerializer.scala
@@ -12,7 +12,7 @@ object ContentDecachedEventSerializer {
     val buffer = new TMemoryBuffer(128)
     val protocol = new TJSONProtocol(buffer)
     event.write(protocol)
-    buffer.toString(StandardCharsets.UTF_8.name())
+    buffer.toString(StandardCharsets.UTF_8)
   }
 
 }

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -69,8 +69,7 @@ class Lambda {
       ContentDecachedEvent(
         path,
         fastlyEventType,
-        decache.contentType
-      )
+        decache.contentType)
     }
   }
 

--- a/src/test/scala/com/gu/fastly/ContentDecachedEventSerializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/ContentDecachedEventSerializerSpec.scala
@@ -1,5 +1,6 @@
 package com.gu.fastly
 
+import org.joda.time.DateTime
 import org.scalatest.{ MustMatchers, OneInstancePerTest, WordSpecLike }
 
 class ContentDecachedEventSerializerSpec extends WordSpecLike with MustMatchers with OneInstancePerTest {
@@ -7,17 +8,19 @@ class ContentDecachedEventSerializerSpec extends WordSpecLike with MustMatchers 
   "Serializer must" must {
 
     "serialize to a SNS compatible string based format" in {
+      val eventPublished = new DateTime(2021, 9, 20, 16, 10, 0, 123)
       val contentDecachedEvent =
         com.gu.fastly.model.event.v1.ContentDecachedEvent(
           contentPath = "/travel/some-content",
           eventType = com.gu.fastly.model.event.v1.EventType.Update,
-          contentType = Some(com.gu.contentapi.client.model.v1.ContentType.Liveblog)
-        )
+          contentType = Some(com.gu.contentapi.client.model.v1.ContentType.Liveblog),
+          eventPublished = Some(eventPublished.getMillis))
 
       val serialized = ContentDecachedEventSerializer.serialize(contentDecachedEvent)
 
       serialized must include("\"1\":{\"str\":\"/travel/some-content\"")
       serialized must include("\"3\":{\"i32\":1")
+      serialized must include("\"5\":{\"i64\":1632150600123")
       serialized must endWith("}")
     }
 

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -17,8 +17,7 @@ class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInsta
   val dt2 = DateTime.now().minusDays(2)
   val fakeAliasPaths = Seq(
     AliasPath("123", CapiDateTime(dt1.getMillis, dt1.withZone(UTC).toString())),
-    AliasPath("abc", CapiDateTime(dt2.getMillis, dt2.withZone(UTC).toString()))
-  )
+    AliasPath("abc", CapiDateTime(dt2.getMillis, dt2.withZone(UTC).toString())))
 
   "Deserializer must" must {
     val event = Event(
@@ -32,9 +31,7 @@ class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInsta
         lastModifiedDate = Some(8888888888L),
         internalRevision = Some(444444),
         contentType = Some(Article),
-        aliasPaths = Some(fakeAliasPaths)
-      )))
-    )
+        aliasPaths = Some(fakeAliasPaths)))))
 
     "properly deserialize a compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, Some(ZstdType), None)


### PR DESCRIPTION
## What does this change?

Populates the `ContentDecachedEvent.eventPublished` field with a timestamp.

This timestamp is intended as an approximate guide to the age of the decache.
Allows downstream apps like Facebook Newstab to decide you aggressively they should retry event processing failures.

Content model update and accept the auto formatters changes.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

- [ ] [Tested with screen reader](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#screen-readers)
- [ ] [Navigable with keyboard](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#keyboard-navigation)
- [ ] [Colour contrast passed](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#colour-contrast)
- [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/source/blob/main/docs/06-accessibility.md#use-of-colour)
