### PR TITLE
Double the number of batches to process concurrently from each shard

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -55,6 +55,7 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       BatchSize: 1
+      ParallelizationFactor: 2
       EventSourceArn: !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStream}"
       FunctionName: !Ref Lambda
       StartingPosition: TRIM_HORIZON


### PR DESCRIPTION
## What does this change?

This doubles the number of batches the lambdas can process **per shard**, with the aim of improving throughput when large updates are triggered e.g. in batch re-tagging operations which prompt large numbers of content updates.

This is an alternative to re-sharding the stream or defining an EFO consumer, and we may yet explore those other methods. This is a first (possibly easiest) step in probing performance and side effects.

## How to test

Deploy it and watch the cloudwatch dashboards.

## How can we measure success?

We currently only use a batch size of one anyway, so any negative side effects should be minimal, and if we don't see an increase in any of the negative metrics (latency, throttling, read throughput exceeded etc.) then we're looking good. 

## Have we considered potential risks?

If the stream exhibits increased numbers in any of the monitored negative stats, we'll revert this change.

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-   [x] N/A
