### PR TITLE
Set up for using an EFO consumer on the firehose stream

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -28,6 +28,15 @@ Parameters:
   KinesisStream:
     Description: Name of the crier kinesis stream
     Type: String
+  StreamEFOConsumer:
+    Description: Name of the Enhanced Fan Out consumer for the kinesis (firehose) stream
+    Type: String
+
+Conditions:
+  IsProd:
+    !Equals
+    - !Ref Stage
+    - PROD
 
 Resources:
   Lambda:
@@ -55,7 +64,11 @@ Resources:
     Type: AWS::Lambda::EventSourceMapping
     Properties:
       BatchSize: 1
-      EventSourceArn: !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStream}"
+      EventSourceArn:
+        !If
+        - IsProd
+        - !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStream}/consumer/${StreamEFOConsumer}"
+        - !Sub "arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${KinesisStream}"
       FunctionName: !Ref Lambda
       StartingPosition: TRIM_HORIZON
   LambdaRole:


### PR DESCRIPTION
## What does this change?

We've (manually) created an Enhanced Fan Out consumer on the PROD firehose kinesis stream, which means this application can be given a dedicated pipe through which to trigger de-cache events, as these are considered important enough to have priority over other consumers.

The identity of the EFO consumer is expressed as a cloudformation parameter.

## How to test

1. Update the cloudformation from this branch
2. Merge this PR
3. Deploy from riff-raff
4. Check that the lambda has a single trigger event which is connected to the correct EFO consumer
5. Check that de-cache events are raised

## How can we measure success?

We should continue to see de-cache events running after the deploy, and over time we expect fewer read throughput exceptions to be recorded against the stream.

## Have we considered potential risks?

If it doesn't work we will have to revert the PR. If this takes too long we can manually connect the lambda's trigger to the original stream and go back to consuming shared bandwidth. 

## Images

N/A

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
-  [ ] None of the above / not applicable
