### PR TITLE
Create IteratorAge alarm for the Fastly Cache Purger

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -31,9 +31,10 @@ Parameters:
   StreamEFOConsumer:
     Description: Name of the Enhanced Fan Out consumer for the kinesis (firehose) stream
     Type: String
-  AlarmTopic:
-    Description: 'A SNS topic ARN for Cloudwatch alerts'
-    Type: String
+  AlarmTopicSSM:
+    Description: 'Pointer to an SNS topic ARN for Cloudwatch alerts'
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /account/content-api-common/alarms/urgent-alarm-topic
 
 Conditions:
   IsProd:
@@ -131,6 +132,6 @@ Resources:
       Threshold: 180000
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:
-        - !If [ IsProd, !Ref AlarmTopic, !Ref "AWS::NoValue" ]
+        - !If [ IsProd, !Ref AlarmTopicSSM, !Ref "AWS::NoValue" ]
       InsufficientDataActions:
-        - !If [ IsProd, !Ref AlarmTopic, !Ref "AWS::NoValue" ]
+        - !If [ IsProd, !Ref AlarmTopicSSM, !Ref "AWS::NoValue" ]

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -31,6 +31,9 @@ Parameters:
   StreamEFOConsumer:
     Description: Name of the Enhanced Fan Out consumer for the kinesis (firehose) stream
     Type: String
+  AlarmTopic:
+    Description: 'A SNS topic ARN for Cloudwatch alerts'
+    Type: String
 
 Conditions:
   IsProd:
@@ -112,3 +115,22 @@ Resources:
     Properties:
       TopicName: !Sub "${App}-${Stage}-decached"
       DisplayName: !Sub '${App}-${Stage}-Decached'
+  IteratorAgeAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub ${Stack}-${Stage}-iterator-age-alarm
+      AlarmDescription: 'Fastly Cache purger is not keeping up with the Firehose.'
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref Lambda
+      MetricName: IteratorAge
+      Statistic: Maximum
+      Period: 60
+      EvaluationPeriods: 1
+      Threshold: 180000
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - !If [ IsProd, !Ref AlarmTopic, !Ref "AWS::NoValue" ]
+      InsufficientDataActions:
+        - !If [ IsProd, !Ref AlarmTopic, !Ref "AWS::NoValue" ]


### PR DESCRIPTION
## What does this change?

There are a few different consumers of the Firehose, with varying levels of importance and life expectency. As a result, we don't want to alert on all of the consumers. The Fastly Cache Purger, however, is a Production level consumer of this stream, and is essential for the publishing workflow. As a result, we should trigger an alarm specifically for this consumer if it falls behind.

The Fastly Cache Purger is a lambda which is configured to have the Kinesis Stream as its event source. Therefore, we can get access directly to the IteratorAge metric for this lambda.

See: https://docs.aws.amazon.com/lambda/latest/dg/monitoring-metrics.html

## How to test

This alarm has currently been deployed directly from the cloudformation and can be seen in the AWS console. I tested it by temporarily putting the threshold low to see it get triggered, and it did. 

## How can we measure success?

This is an alarm, we should be able to monitor it in the AWS console, and if there is an incident it will be triggered.