### PR TITLE
Increase lambda memory allocation

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -50,7 +50,7 @@ Resources:
       Description: Fastly cache purger
       Runtime: java8
       Handler: com.gu.fastly.Lambda::handle
-      MemorySize: 512
+      MemorySize: 768
       Timeout: 30
       Role: !GetAtt LambdaRole.Arn
       ReservedConcurrentExecutions: 10
@@ -60,7 +60,7 @@ Resources:
         - Key: Stage
           Value: !Ref Stage
         - Key: App
-          Value: !Ref App
+          Value: !Ref App]
       Code:
         S3Bucket: !Ref DeployBucket
         S3Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip


### PR DESCRIPTION
## What does this change?

- Updates the cloudformation to increase the lambda's memory allocation size by 50% to 768Mb

This is because we started seeing out-of-memory failures on the PROD environment.  This new value has been tested by updating the lambda in-place (to prevent the incident from escalating) and is confirmed to have fixed the issue

## How to test

Deploy and monitor the lambda graphs (https://eu-west-1.console.aws.amazon.com/lambda/home?region=eu-west-1#/functions/fastly-cache-purger-PROD?tab=monitoring).
You should see 0 errors and you should not see the iterator age increasing.

## How can we measure success?

Purging works properly 😁 

## Have we considered potential risks?

n/a
