### PR TITLE
Update dependencies to reduce number of Snyk vulnerabilties

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "com.gu"
 description := "Lambda for purging Fastly cache based on Crier events"
-scalaVersion := "2.12.8"
+scalaVersion := "2.12.10"
 name := "fastly-cache-purger"
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
   "com.squareup.okhttp3" % "okhttp" % "3.2.0",
   "com.gu" %% "content-api-models-scala" % "17.1.1",
-  "com.gu" %% "thrift-serializer" % "4.0.0",
+  "com.gu" %% "thrift-serializer" % "5.0.2",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",

--- a/build.sbt
+++ b/build.sbt
@@ -4,24 +4,24 @@ scalaVersion := "2.12.10"
 name := "fastly-cache-purger"
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 
-val awsClientVersion = "1.11.918"
+val awsClientVersion = "1.12.388"
 val circeVersion = "0.12.3"
-val Log4jVersion = "2.16.0"
+val Log4jVersion = "2.17.1"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "amazon-kinesis-client" % "1.9.1",
+  "com.amazonaws" % "amazon-kinesis-client" % "1.14.9",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
-  "com.squareup.okhttp3" % "okhttp" % "3.2.0",
+  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "com.gu" %% "content-api-models-scala" % "17.1.1",
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
-  "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
+  "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,

--- a/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
+++ b/src/test/scala/com/gu/fastly/CrierDeserializerSpec.scala
@@ -35,13 +35,13 @@ class CrierDeserializerSpec extends WordSpecLike with MustMatchers with OneInsta
 
     "properly deserialize a compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, Some(ZstdType), None)
-      val compressedEventRecord = new Record().withData(ByteBuffer.wrap(bytes))
+      val compressedEventRecord = new Record().withData(bytes)
       CrierEventDeserializer.eventFromRecord(compressedEventRecord) mustEqual Success(event)
     }
 
     "properly deserialize a non-compressed event" in {
       val bytes = ThriftSerializer.serializeToBytes(event, None, None)
-      val eventRecord = new Record().withData(ByteBuffer.wrap(bytes))
+      val eventRecord = new Record().withData(bytes)
       CrierEventDeserializer.eventFromRecord(eventRecord) mustEqual Success(event)
     }
   }


### PR DESCRIPTION
## What does this change?

This change is motivated by a number of identified snyk vulnerabilities. In order to resolve some of them I am bumping a few dependencies.

## How to test

To confirm that the number of snyk issues has gone down, you can run `snyk test` locally. In every other sense, this change should have no visible effects. Therefore to test it, just make sure pubflow is still showing that content is being updated quickly.

We should also check the logs and make sure we are seeing messages showing that the lambda has purged content correctly.

## How can we measure success?

(slightly) fewer snyk vulnerabilities reported.