### PR TITLE
Fix Snyk High Vulns 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,
+  "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4jVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
   "io.circe" %% "circe-core" % circeVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val circeVersion = "0.12.3"
 val Log4jVersion = "2.17.1"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "amazon-kinesis-client" % "1.14.9",
+  "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
@@ -30,10 +30,10 @@ libraryDependencies ++= Seq(
 
 enablePlugins(RiffRaffArtifact, JavaAppPackaging)
 
-topLevelDirectory in Universal := None
-packageName in Universal := normalizedName.value
+Universal / topLevelDirectory := None
+Universal / packageName := normalizedName.value
 
-riffRaffPackageType := (packageBin in Universal).value
+riffRaffPackageType := (Universal / packageBin).value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := s"Content Platforms::${name.value}"

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ libraryDependencies ++= Seq(
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % Log4jVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
   "io.circe" %% "circe-core" % circeVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -4,24 +4,24 @@ scalaVersion := "2.12.10"
 name := "fastly-cache-purger"
 scalacOptions ++= Seq("-feature", "-deprecation", "-unchecked")
 
-val awsClientVersion = "1.12.388"
-val circeVersion = "0.12.3"
-val Log4jVersion = "2.17.1"
+val awsClientVersion = "1.12.429"
+val circeVersion = "0.14.5"
+val Log4jVersion = "2.20.0"
 
 libraryDependencies ++= Seq(
   "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
-  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
-  "com.gu" %% "content-api-models-scala" % "17.1.1",
+  "com.squareup.okhttp3" % "okhttp" % "4.10.0",
+  "com.gu" %% "content-api-models-scala" % "17.5.1",
   "com.gu" %% "thrift-serializer" % "5.0.2",
   "org.apache.logging.log4j" % "log4j-api" % Log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % Log4jVersion,
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
-  "net.logstash.logback" % "logstash-logback-encoder" % "5.0",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
+  "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,

--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -130,7 +130,7 @@ class Lambda {
 
   // OkHttp requires a media type even for an empty POST body
   private val EmptyJsonBody: RequestBody =
-    RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "")
+    RequestBody.create("", MediaType.parse("application/json; charset=utf-8"))
 
   private sealed trait PurgeType
 


### PR DESCRIPTION
Resolving Snyk vulnerabilities, High vulns are down from 2 to 0 and total from 8 to 1. 

Note: Few other library versions are also upgraded to its latest version (though they were not mentioned by snyk but useful to have), those are
Log4j, aws-lambda-java-core and content-api-models-scala.

## How to test

Tests are running fine after running `sbt test`locally. 
Will test via monitoring logs after merging the PR (as PROD is the only available stack for this at the moment).

## How can we measure success?

Content delivery on platforms should not struggle. Logs should be generated as expected.

## Images

Before: 

<img width="498" alt="image" src="https://user-images.githubusercontent.com/17780995/229074416-9d7d1d4a-5d67-4e01-93c5-58c70058a524.png">

Now:

<img width="502" alt="image" src="https://user-images.githubusercontent.com/17780995/229074211-c015264a-dcf8-4eb5-9f98-33e776923bd2.png">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
