### PR TITLE
Include the decached content path in the sns event

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -1,13 +1,13 @@
 package com.gu.fastly
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
-import com.amazonaws.services.cloudwatch.model.{ Dimension, MetricDatum, PutMetricDataRequest, StandardUnit }
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord
 import com.amazonaws.services.kinesis.model.Record
 import com.amazonaws.services.lambda.runtime.events.KinesisEvent
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
-import com.amazonaws.services.sns.model.PublishRequest
-import com.gu.contentapi.client.model.v1.{ AliasPath, ContentType }
+import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest}
+import com.gu.contentapi.client.model.v1.{AliasPath, ContentType}
 import com.gu.crier.model.event.v1._
 import com.gu.fastly.model.event.v1.ContentDecachedEvent
 import com.gu.googleamp.AmpFlusher
@@ -117,6 +117,7 @@ class Lambda {
           val publishRequest = new PublishRequest()
           publishRequest.setTopicArn(config.decachedContentTopic)
           publishRequest.setMessage(ContentDecachedEventSerializer.serialize(decachedEvent))
+          publishRequest.addMessageAttributesEntry("path", new MessageAttributeValue().withDataType("String").withStringValue(decachedEvent.contentPath))
           snsClient.publish(publishRequest)
         }
       } catch {


### PR DESCRIPTION
Co-authored-by @twrichards 

To integrate with EventBridge (for the purpose of notifying clients via Fastly Fanout - see https://github.com/guardian/fastly-content-fanout/pull/3 and https://github.com/guardian/fastly-content-fanout/pull/4) that content updates have happened.

Specifically, we've included an additional ['message attribute'](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html) on the decached event to hold the path (which we use as the 'channel' for Fanout) - this is preferable to working with the Thrift serialized event structure (in the body of the event).

---

This is probably a more sensible alternative to https://github.com/guardian/crier/pull/160 since this will only notify once the cache is purged, i.e. when the content is definitely available to the clients (so no eTag checking required) - however there is no CODE env for the cache purger, so might need to merge https://github.com/guardian/crier/pull/160 so we can generate notifications when developing clients (by 'launching' content changes in composer CODE).

