### PR TITLE
CFN export for the ARN of the 

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -137,3 +137,11 @@ Resources:
         - !If [ IsProd, !Ref AlarmTopicSSM, !Ref "AWS::NoValue" ]
       InsufficientDataActions:
         - !If [ IsProd, !Ref AlarmTopicSSM, !Ref "AWS::NoValue" ]
+
+Outputs:
+  DecachedContentSNSTopicARN:
+    Description: ARN of the SNS DecachedContentTopic
+    Value:
+      Ref: DecachedContentTopic
+    Export:
+      Name: !Sub "${AWS::StackName}-DecachedContentSNSTopicARN"


### PR DESCRIPTION
In order to facilitate https://github.com/guardian/fastly-content-fanout/pull/4 (see also https://github.com/guardian/fastly-cache-purger/pull/78) we'd like to import the ARN of the SNS `DecachedContentTopic` so we can wire up an SQS & EventBridge Pipe in order to notify clients (app & web) that content updates are available.

Similar to https://github.com/guardian/editorial-tools-platform/pull/752 (for Fronts).