### PR TITLE
Give Ophan access to sns topic

### DIFF
--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -35,6 +35,10 @@ Parameters:
     Description: 'Pointer to an SNS topic ARN for Cloudwatch alerts'
     Type: AWS::SSM::Parameter::Value<String>
     Default: /account/content-api-common/alarms/urgent-alarm-topic
+  OphanAccountID:
+    Description: 'AWS account/profile ID of Ophan'
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: OphanAccountID
 
 Conditions:
   IsProd:
@@ -118,6 +122,19 @@ Resources:
     Properties:
       TopicName: !Sub "${App}-${Stage}-decached"
       DisplayName: !Sub '${App}-${Stage}-Decached'
+  DecachedContentTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref DecachedContentTopic
+      PolicyDocument:
+        Statement:
+          - Sid: OphanAccount
+            Effect: Allow
+            Principal:
+              AWS: !Ref 'OphanAccountID'
+            Action: "sns:Subscribe"
+            Resource: !Ref 'DecachedContentTopic'
   IteratorAgeAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
## What does this change?

Ophan are looking to subscribe to this SNS topic (see https://github.com/guardian/ophan/issues/5927 for more info).

Param for ophan account ID created [here](https://eu-west-1.console.aws.amazon.com/systems-manager/parameters/OphanAccountID/description?region=eu-west-1&tab=Table#list_parameter_filters=Name:Contains:OphanAccount)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
