### PR TITLE
Reduce sensitivity of iterator age alarm to avoid spurious alerts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
       contents: read
       checks: write
-      issues: read
+      issues: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
       id-token: write
       contents: read
       checks: write
-      issues: write
+      issues: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           SBT_JUNIT_OUTPUT: ./junit-tests
         run: sbt 'test;assembly'
 
-      - uses: EnricoMi/publish-unit-test-result-action@v1
+      - uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()  #runs even if there is a test failure
         with:
           files: junit-tests/*.xml

--- a/cloudformation.yaml
+++ b/cloudformation.yaml
@@ -147,7 +147,7 @@ Resources:
       MetricName: IteratorAge
       Statistic: Maximum
       Period: 60
-      EvaluationPeriods: 1
+      EvaluationPeriods: 5
       Threshold: 180000
       ComparisonOperator: GreaterThanThreshold
       AlarmActions:


### PR DESCRIPTION
## What does this change?

Requires 5 breaching datapoints (iterator age >3min) before triggering an alert.   Datapoints are every 60s; we have been seeing spurious alerts due to some data points being missing so this should quieten the spurious alerts while not causing much of a precision loss (given that the iterator age must be >3min we would detect a ramping within 5min instead of 3min which is still less time than it would take someone to go and investigate) 

## How to test

Deploy the cloudformation and check the alert config

## How can we measure success?

Less spurious errors from PagerDuty

## Have we considered potential risks?

The only risk is a loss of precision but that is marginal, see the first section.
