### PR TITLE
Update jackson-core to remove snyk vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.4",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
   "com.gu" %% "content-api-models-scala" % "17.5.1",
   "com.gu" %% "thrift-serializer" % "5.0.2",

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sns" % awsClientVersion,
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.4",
   "com.squareup.okhttp3" % "okhttp" % "4.10.0",
   "com.gu" %% "content-api-models-scala" % "17.5.1",
   "com.gu" %% "thrift-serializer" % "5.0.2",
@@ -28,6 +27,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.scalatest" %% "scalatest" % "3.0.0" % "test"
 )
+
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.15.4"
 
 ThisBuild / assemblyJarName := "fastly-cache-purger.jar"
 ThisBuild / assemblyMergeStrategy := {


### PR DESCRIPTION
Snyk has reported [a high-severity vulnerability in jackson-core](https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538). While the maintainers of jackson and play are sceptical about its severity, it’s easier for us to manually update it than figure out whether we’re actually vulnerable.

Snyk reports any version from 2.15.0 forward as having the fix, so I’ve added a dependency on jackson-core:2.15.4 to evict the lower version in our transitive dependencies (which comes from various aws dependencies and logstash-logback-encoder).

I haven’t upgraded to the newest possible version for now, as we can probably remove this explicit dependency when we update our other dependencies, and they may not move to the newest version of jackson (which might produce an odd downgrade for us).