### PR TITLE
Describe deployment process in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,6 @@ This value should be set to at least the number of Kinesis trigger shards.
 
 ## Deployment
 
-This app is currently only deployed to PROD: there is no CODE stack. Also, [the Riff Raff configuration](./riff-raff.yaml) is only set to deploy the lambda updates: it doesn’t update the cloudformation.
+This app is currently only deployed to PROD: there is no CODE stack. Also, [the Riff Raff configuration](./riff-raff.yaml) is only set to deploy the lambda updates: it doesn’t update the cloudformation. If you need to make changes to the cloudformation, you will have to deploy those manually by applying [the cloudformation.yaml](./cloudformation.yaml) in the AWS console.
 
-There is also no continuous deployment configured in Riff Raff for this app at the moment: since one must manually update the cloudformation, it’s probably safest to let people deploy when they’re ready, so that they can make sure to apply [the cloudformation](./cloudformation.yaml) first.
+There is also no continuous deployment configured in Riff Raff for this app at the moment: since one must manually update the cloudformation, it’s probably safest to let people deploy when they’re ready, so that they can make sure to apply the cloudformation first.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ To protect this Lambda from other rouge Lambdas consuming all the available shar
 
 This value should be set to at least the number of Kinesis trigger shards.
 
+## Deployment
 
+This app is currently only deployed to PROD: there is no CODE stack. Also, [the Riff Raff configuration](./riff-raff.yaml) is only set to deploy the lambda updates: it doesn’t update the cloudformation.
 
-
+There is also no continuous deployment configured in Riff Raff for this app at the moment: since one must manually update the cloudformation, it’s probably safest to let people deploy when they’re ready, so that they can make sure to apply [the cloudformation](./cloudformation.yaml) first.

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -4,6 +4,9 @@ stacks:
 regions:
   - eu-west-1
 
+allowedStages:
+  - PROD
+
 deployments:
   fastly-cache-purger:
     type: aws-lambda


### PR DESCRIPTION
Before now, the deployment process was not described in the readme – it was not immediately clear that one must manually update the cloudformation, or run a manual deployment after merging to main.

Having this explained in the readme would have saved me a small bit of working out recently, so this PR does that.