### PR TITLE
Update versions of jackson-core and protobuf-java re high snyk vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val circeVersion = "0.14.5"
 val Log4jVersion = "2.20.0"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "amazon-kinesis-client" % "1.14.10" exclude("com.fasterxml.jackson.core", "jackson-core") exclude("com.google.protobuf", "protobuf-java"),
+  "com.amazonaws" % "amazon-kinesis-client" % "1.15.2" exclude("com.google.protobuf", "protobuf-java"),
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
@@ -26,8 +26,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
-  "com.google.protobuf" % "protobuf-java" % "3.25.5"
+  "com.google.protobuf" % "protobuf-java" % "4.28.2"
 )
 
 ThisBuild / assemblyJarName := "fastly-cache-purger.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val circeVersion = "0.14.5"
 val Log4jVersion = "2.20.0"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "amazon-kinesis-client" % "1.14.10",
+  "com.amazonaws" % "amazon-kinesis-client" % "1.14.10" exclude("com.fasterxml.jackson.core", "jackson-core") exclude("com.google.protobuf", "protobuf-java"),
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
@@ -25,7 +25,9 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+  "org.scalatest" %% "scalatest" % "3.0.0" % "test",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.15.0",
+  "com.google.protobuf" % "protobuf-java" % "3.25.5"
 )
 
 ThisBuild / assemblyJarName := "fastly-cache-purger.jar"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates versions of the following to address snyk high vulnerabilities:
- amazon-kinesis-client
- protobuf-java

## How to test

Run `sbt test` - tests pass

As PROD is the only available stack, logs will be monitored after merging the PR

## How can we measure success?

Synk high vulnerabilities removed

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
