### PR TITLE
Fix CI on main (formatting)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,10 @@ val circeVersion = "0.14.5"
 val Log4jVersion = "2.20.0"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "amazon-kinesis-client" % "1.15.2" exclude("com.google.protobuf", "protobuf-java"),
+  "com.amazonaws" % "amazon-kinesis-client" % "1.15.2" exclude (
+    "com.google.protobuf",
+    "protobuf-java"
+  ),
   "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
   "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,


### PR DESCRIPTION
## What does this change?

Currently [the build on main is failing](https://github.com/guardian/fastly-cache-purger/actions/runs/11478015225/job/31941323876), due to a formatting check I introduced in [pull 86](https://github.com/guardian/fastly-cache-purger/pull/86).

This is because [pull 87](https://github.com/guardian/fastly-cache-purger/pull/87) introduced incorrect formatting, because [the last check on the PR (which passed)](https://github.com/guardian/fastly-cache-purger/actions/runs/11476359103/job/31936195710) didn’t include the formatting check.

This is because that PR had branched off main before the new formatting check was introduced: the first commit in the PR is [9fb8358fc](https://github.com/guardian/fastly-cache-purger/commits/9fb8358fc2c81b4c75e4102f98bf9ac8149d9cd9), whose parent is from January, before the formatting check was introduced.

Two things might have helped here:

- If the CI ran on the `pull_request` trigger rather than `push`, it would have run on a merge commit with main and so would have included the formatting check
- If the repo had required PRs to be up to date before merge, rebasing the PR on latest main would’ve included the formatting check

I think we should change both of these things to prevent this happening in future.

## How to test

- see that the PR CI succeeds, and includes the formatting test