### PR TITLE
Add additional path for email headline purging

### DIFF
--- a/src/main/scala/com/gu/fastly/Lambda.scala
+++ b/src/main/scala/com/gu/fastly/Lambda.scala
@@ -64,7 +64,8 @@ class Lambda {
       case Soft => Seq(dotcomAliasPurge, jsonAliasPurge, mapiAliasPurge)
     }
 
-    val pathsToPurge = Seq(event.payloadId) ++ extractAliasPaths(event)
+    val pathsToPurge = (Seq(event.payloadId) ++ extractAliasPaths(event))
+      .flatMap(path => Seq(path) ++ additionalPathsForPurge(path))
 
     val wasSuccessful: Boolean = pathsToPurge
       .flatMap { path =>
@@ -270,6 +271,10 @@ class Lambda {
       }
     }
   }
+
+  def additionalPathsForPurge(path: String): Seq[String] =
+    if (path.startsWith("email/")) Seq(s"$path/headline.txt")
+    else Seq.empty
 
   // Count the number of purge requests we are making
   private def sendPurgeCountMetric(contentType: Option[ContentType]): Unit = {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
